### PR TITLE
Register user token store as scoped

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
@@ -61,7 +61,7 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
     public static IServiceCollection AddBlazorServerAccessTokenManagement<TTokenStore>(this IServiceCollection services)
         where TTokenStore : class, IUserTokenStore
     {
-        services.AddSingleton<IUserTokenStore, TTokenStore>();
+        services.AddScoped<IUserTokenStore, TTokenStore>();
         services.AddScoped<IUserAccessor, BlazorServerUserAccessor>();
         services.AddCircuitServicesAccessor();
         services.AddHttpContextAccessor(); // For SSR


### PR DESCRIPTION
In blazor implementations of the token store, you might want to depend on the auth state provider. That can't be resolved in a singleton context, so we shouldn't register this dependency as a singleton.

**What issue does this PR address?**
Related to: https://github.com/DuendeSoftware/BFF/issues/207

