### PR TITLE
Add support for .NET 9 to access token management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,17 +18,14 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <FrameworkVersion>8.0.1</FrameworkVersion>
     <ExtensionsVersion>8.0.0</ExtensionsVersion>
-     
-    <!-- TODO - we may want to lower the upper bound as we do more testing. -->
-    <WilsonVersion>[7.1.2,8.0.0)</WilsonVersion> 
-    
+    <WilsonVersion>[8.0.1,9.0.0)</WilsonVersion> 
     <IdentityServerVersion>7.0.8</IdentityServerVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0'">
     <FrameworkVersion>9.0.0</FrameworkVersion>
     <ExtensionsVersion>9.0.0</ExtensionsVersion>
-    <WilsonVersion>8.0.1</WilsonVersion>
+    <WilsonVersion>[8.0.1,9.0.0)</WilsonVersion>
     <IdentityServerVersion>7.0.8</IdentityServerVersion>
   </PropertyGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,21 +11,24 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0'">
     <FrameworkVersion>6.0.1</FrameworkVersion>
     <ExtensionsVersion>6.0.0</ExtensionsVersion>
-    <WilsonVersion>7.1.2</WilsonVersion>
-    <IdentityServerVersion>6.1.8</IdentityServerVersion>
+    <WilsonVersion>6.35.0</WilsonVersion>
+    <IdentityServerVersion>6.3.10</IdentityServerVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <FrameworkVersion>8.0.1</FrameworkVersion>
     <ExtensionsVersion>8.0.0</ExtensionsVersion>
-    <WilsonVersion>7.1.2</WilsonVersion>
+     
+    <!-- TODO - we may want to lower the upper bound as we do more testing. -->
+    <WilsonVersion>[7.1.2,8.0.0)</WilsonVersion> 
+    
     <IdentityServerVersion>7.0.8</IdentityServerVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0'">
     <FrameworkVersion>9.0.0</FrameworkVersion>
     <ExtensionsVersion>9.0.0</ExtensionsVersion>
-    <WilsonVersion>8.0.0</WilsonVersion>
+    <WilsonVersion>8.0.1</WilsonVersion>
     <IdentityServerVersion>7.0.8</IdentityServerVersion>
   </PropertyGroup>
 
@@ -57,6 +60,7 @@
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(WilsonVersion)" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(WilsonVersion)" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Verify.Xunit" Version="27.0.1" />
     <PackageVersion Include="xunit.core" Version="2.9.2" />

--- a/access-token-management/global.json
+++ b/access-token-management/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/AccessTokenManagement.OpenIdConnect.csproj
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/AccessTokenManagement.OpenIdConnect.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AccessTokenManagement\AccessTokenManagement.csproj" />

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/AccessTokenManagement.OpenIdConnect.csproj
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/AccessTokenManagement.OpenIdConnect.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PackageId>Duende.AccessTokenManagement.OpenIdConnect</PackageId>
     <AssemblyName>$(PackageId)</AssemblyName>
     <RootNamespace>$(PackageId)</RootNamespace>

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
@@ -71,20 +71,7 @@ public class OpenIdConnectConfigurationService : IOpenIdConnectConfigurationServ
             
             Authority = options.Authority,
             TokenEndpoint = configuration.TokenEndpoint,
-            
-            // This conditional compilation is required because the
-            // OpenIdConnectConfiguration type in
-            // Microsoft.IdentityModel.Protocols.OpenIdConnect has a breaking
-            // change in version 8.0.0 that library. The revocation endpoint was
-            // added as a strongly typed property, which means it is no longer
-            // included in the AdditionalData. In our .NET 9 build, we require
-            // wilson >8.0.0, and in our .NET 8 build, we require wilson <8.0.0.
-#if NET9_0_OR_GREATER
             RevocationEndpoint = configuration.RevocationEndpoint,            
-#else
-            RevocationEndpoint = configuration.AdditionalData.TryGetValue(OidcConstants.Discovery.RevocationEndpoint, out var value) ? value?.ToString() : null,
-#endif
-            
             ClientId = options.ClientId,
             ClientSecret = options.ClientSecret,
             HttpClient = options.Backchannel,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
@@ -71,7 +71,19 @@ public class OpenIdConnectConfigurationService : IOpenIdConnectConfigurationServ
             
             Authority = options.Authority,
             TokenEndpoint = configuration.TokenEndpoint,
+            
+            // This conditional compilation is required because the
+            // OpenIdConnectConfiguration type in
+            // Microsoft.IdentityModel.Protocols.OpenIdConnect has a breaking
+            // change in version 8.0.0 that library. The revocation endpoint was
+            // added as a strongly typed property, which means it is no longer
+            // included in the AdditionalData. In our .NET 9 build, we require
+            // wilson >8.0.0, and in our .NET 8 build, we require wilson <8.0.0.
+#if NET9_0_OR_GREATER
+            RevocationEndpoint = configuration.RevocationEndpoint,            
+#else
             RevocationEndpoint = configuration.AdditionalData.TryGetValue(OidcConstants.Discovery.RevocationEndpoint, out var value) ? value?.ToString() : null,
+#endif
             
             ClientId = options.ClientId,
             ClientSecret = options.ClientSecret,

--- a/access-token-management/src/AccessTokenManagement/AccessTokenManagement.csproj
+++ b/access-token-management/src/AccessTokenManagement/AccessTokenManagement.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PackageId>Duende.AccessTokenManagement</PackageId>
     <AssemblyName>$(PackageId)</AssemblyName>
     <RootNamespace>$(PackageId)</RootNamespace>

--- a/access-token-management/test/AccessTokenManagement.Tests/AccessTokenManagement.Tests.csproj
+++ b/access-token-management/test/AccessTokenManagement.Tests/AccessTokenManagement.Tests.csproj
@@ -15,10 +15,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
 
-    <!-- Pinned to avoid conflicts - we bring this in via IdentityServer, and that could conflict with 
-     AccessTokenManagement's depednecy on System.IdentityModel.Tokens.Jwt. -->
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
-
     <PackageReference Include="RichardSzalay.MockHttp" />
   </ItemGroup>
   <ItemGroup>

--- a/access-token-management/test/AccessTokenManagement.Tests/AccessTokenManagement.Tests.csproj
+++ b/access-token-management/test/AccessTokenManagement.Tests/AccessTokenManagement.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Duende.AccessTokenManagement</RootNamespace>
@@ -14,6 +14,11 @@
     <PackageReference Include="Duende.IdentityServer"/>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+
+    <!-- Pinned to avoid conflicts - we bring this in via IdentityServer, and that could conflict with 
+     AccessTokenManagement's depednecy on System.IdentityModel.Tokens.Jwt. -->
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
+
     <PackageReference Include="RichardSzalay.MockHttp" />
   </ItemGroup>
   <ItemGroup>

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
@@ -218,7 +218,7 @@ public class AppHost : GenericHost
         response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
         response.StatusCode.ShouldBe((HttpStatusCode)302); // root
 
-        response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
+        response = await BrowserClient.GetAsync(Url(response.Headers.Location!.ToString()));
         return response;
     }
 }

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
@@ -58,6 +58,11 @@ public class AppHost : GenericHost
             })
             .AddOpenIdConnect("oidc", options =>
             {
+                options.Events.OnRedirectToIdentityProviderForSignOut = async e =>
+                {
+                    await e.HttpContext.RevokeRefreshTokenAsync();
+                };
+                
                 options.Authority = _identityServerHost.Url();
 
                 options.ClientId = ClientId;
@@ -212,7 +217,6 @@ public class AppHost : GenericHost
 
         response = await BrowserClient.GetAsync(response.Headers.Location.ToString());
         response.StatusCode.ShouldBe((HttpStatusCode)302); // root
-        response.Headers.Location!.ToString().ToLowerInvariant().ShouldBe("/");
 
         response = await BrowserClient.GetAsync(Url(response.Headers.Location.ToString()));
         return response;

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/IdentityServerHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/IdentityServerHost.cs
@@ -53,6 +53,9 @@ public class IdentityServerHost : GenericHost
                 // Artificially low durations to force retries
                 options.DPoP.ServerClockSkew = TimeSpan.Zero;
                 options.DPoP.ProofTokenValidityDuration = TimeSpan.FromSeconds(1);
+                
+                // Disable PAR (this keeps test setup simple, and we don't need to integration test PAR here - it is covered by IdentityServer itself)
+                options.Endpoints.EnablePushedAuthorizationEndpoint = false;
             })
             .AddInMemoryClients(Clients)
             .AddInMemoryIdentityResources(IdentityResources)

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/DPoPProofTokenFactory.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/DPoPProofTokenFactory.cs
@@ -4,7 +4,6 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using Duende.IdentityModel;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -24,7 +23,7 @@ public class DPoPProofTokenFactory
     {
         _jwk = new JsonWebKey(proofKey);
 
-        if (_jwk.Alg.IsNullOrEmpty())
+        if (string.IsNullOrEmpty(_jwk.Alg))
         {
             throw new ArgumentException("alg must be set on proof key");
         }

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/IdentityModel.OidcClient.Tests.csproj
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/IdentityModel.OidcClient.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.Extensions.Primitives" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 </Project>

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRevocationExtensions.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRevocationExtensions.cs
@@ -12,7 +12,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
 {
     public class TokenRevocationExtensionsTests
     {
-        private const string Endpoint = "http://server/endoint";
+        private const string Endpoint = "http://server/endpoint";
 
         [Fact]
         public async Task Http_request_should_have_correct_format()


### PR DESCRIPTION
Related to #45, but we will do more testing (all wilson versions?) before closing.