### PR TITLE
Pin GHA dependencies

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -151,7 +151,7 @@ git push origin {component.TagPrefix}-{contexts.Event.Input.Version}");
         .Environment("nuget.org", "");
 
     publishJob.Step()
-        .Uses("actions/download-artifact@v4")
+        .Uses("actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16") // 4.1.8
         .With(("name", "artifacts"), ("path", "artifacts"));
 
     publishJob.StepSetupDotNet();
@@ -186,7 +186,7 @@ public static class StepExtensions
     public static void StepSetupDotNet(this Job job)
         => job.Step()
             .Name("Setup .NET")
-            .ActionsSetupDotNet(["6.0.x", "8.0.x", "9.0.x"]);
+            .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["6.0.x", "8.0.x", "9.0.x"]); // v4.1.0
 
     public static Step IfRefMain(this Step step) 
         => step.If("github.ref == 'refs/heads/main'");
@@ -204,7 +204,7 @@ public static class StepExtensions
 
         job.Step()
             .Name($"Test report - {testProject}")
-            .Uses("dorny/test-reporter@v1")
+            .Uses("dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5") // v1.9.1
             .If("success() || failure()")
             .With(
                 ("name", $"Test Report - {testProject}"),
@@ -272,7 +272,7 @@ public static class StepExtensions
         job.Step()
             .Name("Upload Artifacts")
             .IfRefMain()
-            .Uses("actions/upload-artifact@v4")
+            .Uses("actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882") // 4.4.3
             .With(
                 ("name", "artifacts"),
                 ("path", path),

--- a/.github/workflows/access-token-management-ci.yml
+++ b/.github/workflows/access-token-management-ci.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -41,7 +41,7 @@ jobs:
       run: dotnet test -c Release test/AccessTokenManagement.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - AccessTokenManagement.Tests
       if: success() || failure()
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - AccessTokenManagement.Tests
         path: access-token-management/test/AccessTokenManagement.Tests/TestResults/Tests.trx
@@ -77,7 +77,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: access-token-management/artifacts/*.nupkg

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -70,7 +70,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: access-token-management/artifacts/*.nupkg
@@ -84,12 +84,12 @@ jobs:
     environment:
       name: nuget.org
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         name: artifacts
         path: artifacts
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,14 +18,14 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses:  github/codeql-action/init@v3
+      uses:  github/codeql-action/init@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # 3.27.4
       with:
         languages: csharp
         
     - name: Auto build
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # 3.27.4
 
     - name: Perform CodeQL analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@ea9e4e37992a54ee68a9622e985e60c8e8f12d9f # 3.27.4
       with:
         category: "/language:csharp"

--- a/.github/workflows/identity-model-ci.yml
+++ b/.github/workflows/identity-model-ci.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -41,7 +41,7 @@ jobs:
       run: dotnet test -c Release test/IdentityModel.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - IdentityModel.Tests
       if: success() || failure()
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - IdentityModel.Tests
         path: identity-model/test/IdentityModel.Tests/TestResults/Tests.trx
@@ -75,7 +75,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: identity-model/artifacts/*.nupkg

--- a/.github/workflows/identity-model-oidc-client-ci.yml
+++ b/.github/workflows/identity-model-oidc-client-ci.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -41,7 +41,7 @@ jobs:
       run: dotnet test -c Release test/IdentityModel.OidcClient.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - IdentityModel.OidcClient.Tests
       if: success() || failure()
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - IdentityModel.OidcClient.Tests
         path: identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/TestResults/Tests.trx
@@ -77,7 +77,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: identity-model-oidc-client/artifacts/*.nupkg

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -70,7 +70,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: identity-model-oidc-client/artifacts/*.nupkg
@@ -84,12 +84,12 @@ jobs:
     environment:
       name: nuget.org
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         name: artifacts
         path: artifacts
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -68,7 +68,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: identity-model/artifacts/*.nupkg
@@ -82,12 +82,12 @@ jobs:
     environment:
       name: nuget.org
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         name: artifacts
         path: artifacts
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x

--- a/.github/workflows/ignore-this-ci.yml
+++ b/.github/workflows/ignore-this-ci.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -41,7 +41,7 @@ jobs:
       run: dotnet test -c Release test/IgnoreThis.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - IgnoreThis.Tests
       if: success() || failure()
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - IgnoreThis.Tests
         path: ignore-this/test/IgnoreThis.Tests/TestResults/Tests.trx
@@ -75,7 +75,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: ignore-this/artifacts/*.nupkg

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x
@@ -68,7 +68,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload Artifacts
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       with:
         name: artifacts
         path: ignore-this/artifacts/*.nupkg
@@ -82,12 +82,12 @@ jobs:
     environment:
       name: nuget.org
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
         name: artifacts
         path: artifacts
     - name: Setup Dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:
         dotnet-version: |-
           6.0.x


### PR DESCRIPTION
Pins all GitHub action workflow dependencies using the commit sha. Addresses OSSF scorecard notifications.