### PR TITLE
Implement all properties for TokenIntrospectionResponse optional claims

### DIFF
--- a/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
@@ -87,8 +87,8 @@ public class TokenIntrospectionResponse : ProtocolResponse
     {
         var claimValue = claims.FirstOrDefault(e => e.Type == claimType)?.Value;
         if (claimValue == null) return null;
+        if (!long.TryParse(claimValue, NumberStyles.AllowLeadingSign, NumberFormatInfo.InvariantInfo, out var seconds)) return null;
 
-        var seconds = long.Parse(claimValue, NumberStyles.AllowLeadingSign, NumberFormatInfo.InvariantInfo);
         return DateTimeOffset.FromUnixTimeSeconds(seconds);
     }
 
@@ -136,7 +136,7 @@ public class TokenIntrospectionResponse : ProtocolResponse
     /// Gets the time on or after which the token must not be accepted for processing.
     /// </summary>
     /// <value>
-    /// The expiration time of the token or null if the <c>exp</c> claim is missing.
+    /// The expiration time of the token or null if the <c>exp</c> claim is either missing or not a valid number.
     /// </value>
     public DateTimeOffset? Expiration { get; private set; }
 
@@ -144,7 +144,7 @@ public class TokenIntrospectionResponse : ProtocolResponse
     /// Gets the time when the token was issued.
     /// </summary>
     /// <value>
-    /// The issuance time of the token or null if the <c>iat</c> claim is missing.
+    /// The issuance time of the token or null if the <c>iat</c> claim is either missing or not a valid number.
     /// </value>
     public DateTimeOffset? IssuedAt { get; private set; }
 
@@ -152,7 +152,7 @@ public class TokenIntrospectionResponse : ProtocolResponse
     /// Gets the time before which the token must not be accepted for processing.
     /// </summary>
     /// <value>
-    /// The validity start time of the token or null if the <c>nbf</c> claim is missing.
+    /// The validity start time of the token or null if the <c>nbf</c> claim is either missing or not a valid number.
     /// </value>
     public DateTimeOffset? NotBefore { get; private set; }
 

--- a/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityModel.Validation;
@@ -15,6 +16,14 @@ namespace Duende.IdentityModel.Client;
 /// <seealso cref="ProtocolResponse" />
 public class TokenIntrospectionResponse : ProtocolResponse
 {
+    private DateTimeOffset? _expiration;
+    private DateTimeOffset? _issuedAt;
+    private DateTimeOffset? _notBefore;
+
+    private ExceptionDispatchInfo? _expirationException;
+    private ExceptionDispatchInfo? _issuedAtException;
+    private ExceptionDispatchInfo? _notBeforeException;
+
     /// <summary>
     /// Allows to initialize instance specific data.
     /// </summary>
@@ -70,9 +79,9 @@ public class TokenIntrospectionResponse : ProtocolResponse
         ClientId = claims.FirstOrDefault(c => c.Type == JwtClaimTypes.ClientId)?.Value;
         UserName = claims.FirstOrDefault(c => c.Type == "username")?.Value;
         TokenType = claims.FirstOrDefault(c => c.Type == "token_type")?.Value;
-        Expiration = GetTime(claims, JwtClaimTypes.Expiration);
-        IssuedAt = GetTime(claims, JwtClaimTypes.IssuedAt);
-        NotBefore = GetTime(claims, JwtClaimTypes.NotBefore);
+        _expiration = GetDateTimeOffset(claims, JwtClaimTypes.Expiration, ref _expirationException);
+        _issuedAt = GetDateTimeOffset(claims, JwtClaimTypes.IssuedAt, ref _issuedAtException);
+        _notBefore = GetDateTimeOffset(claims, JwtClaimTypes.NotBefore, ref _notBeforeException);
         Subject = claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject)?.Value;
         Audiences = claims.Where(c => c.Type == JwtClaimTypes.Audience).Select(c => c.Value).ToArray();
         Issuer = claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Issuer)?.Value;
@@ -83,13 +92,24 @@ public class TokenIntrospectionResponse : ProtocolResponse
         return Task.CompletedTask;
     }
 
-    private static DateTimeOffset? GetTime(List<Claim> claims, string claimType)
+    private static DateTimeOffset? GetDateTimeOffset(List<Claim> claims, string claimType, ref ExceptionDispatchInfo? exceptionDispatchInfo)
     {
         var claimValue = claims.FirstOrDefault(e => e.Type == claimType)?.Value;
-        if (claimValue == null) return null;
-        if (!long.TryParse(claimValue, NumberStyles.AllowLeadingSign, NumberFormatInfo.InvariantInfo, out var seconds)) return null;
+        if (claimValue == null)
+        {
+            return null;
+        }
 
-        return DateTimeOffset.FromUnixTimeSeconds(seconds);
+        try
+        {
+            var seconds = long.Parse(claimValue, NumberStyles.AllowLeadingSign, NumberFormatInfo.InvariantInfo);
+            return DateTimeOffset.FromUnixTimeSeconds(seconds);
+        }
+        catch (Exception exception)
+        {
+            exceptionDispatchInfo = ExceptionDispatchInfo.Capture(exception);
+            return null;
+        }
     }
 
     /// <summary>
@@ -136,25 +156,46 @@ public class TokenIntrospectionResponse : ProtocolResponse
     /// Gets the time on or after which the token must not be accepted for processing.
     /// </summary>
     /// <value>
-    /// The expiration time of the token or null if the <c>exp</c> claim is either missing or not a valid number.
+    /// The expiration time of the token or null if the <c>exp</c> claim is missing.
     /// </value>
-    public DateTimeOffset? Expiration { get; private set; }
+    public DateTimeOffset? Expiration
+    {
+        get
+        {
+            _expirationException?.Throw();
+            return _expiration;
+        }
+    }
 
     /// <summary>
     /// Gets the time when the token was issued.
     /// </summary>
     /// <value>
-    /// The issuance time of the token or null if the <c>iat</c> claim is either missing or not a valid number.
+    /// The issuance time of the token or null if the <c>iat</c> claim is missing.
     /// </value>
-    public DateTimeOffset? IssuedAt { get; private set; }
+    public DateTimeOffset? IssuedAt
+    {
+        get
+        {
+            _issuedAtException?.Throw();
+            return _issuedAt;
+        }
+    }
 
     /// <summary>
     /// Gets the time before which the token must not be accepted for processing.
     /// </summary>
     /// <value>
-    /// The validity start time of the token or null if the <c>nbf</c> claim is either missing or not a valid number.
+    /// The validity start time of the token or null if the <c>nbf</c> claim is missing.
     /// </value>
-    public DateTimeOffset? NotBefore { get; private set; }
+    public DateTimeOffset? NotBefore
+    {
+        get
+        {
+            _notBeforeException?.Throw();
+            return _notBefore;
+        }
+    }
 
     /// <summary>
     /// Gets the subject of the token. Usually a machine-readable identifier of the resource owner who authorized the token.

--- a/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Globalization;
 using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityModel.Validation;
@@ -9,11 +10,50 @@ using static Duende.IdentityModel.JwtClaimTypes;
 namespace Duende.IdentityModel.Client;
 
 /// <summary>
-/// Models an OAuth 2.0 introspection response
+/// Models an OAuth 2.0 introspection response as defined by <a href="https://datatracker.ietf.org/doc/html/rfc7662">RFC 7662 - OAuth 2.0 Token Introspection</a>
 /// </summary>
 /// <seealso cref="ProtocolResponse" />
 public class TokenIntrospectionResponse : ProtocolResponse
 {
+    private readonly Lazy<string[]> _scopes;
+    private readonly Lazy<string?> _clientId;
+    private readonly Lazy<string?> _userName;
+    private readonly Lazy<string?> _tokenType;
+    private readonly Lazy<DateTimeOffset?> _expiration;
+    private readonly Lazy<DateTimeOffset?> _issuedAt;
+    private readonly Lazy<DateTimeOffset?> _notBefore;
+    private readonly Lazy<string?> _subject;
+    private readonly Lazy<string[]> _audiences;
+    private readonly Lazy<string?> _issuer;
+    private readonly Lazy<string?> _jwtId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenIntrospectionResponse"/> class.
+    /// </summary>
+    public TokenIntrospectionResponse()
+    {
+        _scopes = new Lazy<string[]>(() => Claims.Where(c => c.Type == JwtClaimTypes.Scope).Select(c => c.Value).ToArray());
+        _clientId = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.ClientId)?.Value);
+        _userName = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == "username")?.Value);
+        _tokenType = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == "token_type")?.Value);
+        _expiration = new Lazy<DateTimeOffset?>(() => GetTime(JwtClaimTypes.Expiration));
+        _issuedAt = new Lazy<DateTimeOffset?>(() => GetTime(JwtClaimTypes.IssuedAt));
+        _notBefore = new Lazy<DateTimeOffset?>(() => GetTime(JwtClaimTypes.NotBefore));
+        _subject = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject)?.Value);
+        _audiences = new Lazy<string[]>(() => Claims.Where(c => c.Type == JwtClaimTypes.Audience).Select(c => c.Value).ToArray());
+        _issuer = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Issuer)?.Value);
+        _jwtId = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.JwtId)?.Value);
+    }
+
+    private DateTimeOffset? GetTime(string claimType)
+    {
+        var claimValue = Claims.FirstOrDefault(e => e.Type == claimType)?.Value;
+        if (claimValue == null) return null;
+
+        var seconds = long.Parse(claimValue, NumberStyles.AllowLeadingSign, NumberFormatInfo.InvariantInfo);
+        return DateTimeOffset.FromUnixTimeSeconds(seconds);
+    }
+
     /// <summary>
     /// Allows to initialize instance specific data.
     /// </summary>
@@ -77,6 +117,94 @@ public class TokenIntrospectionResponse : ProtocolResponse
     ///   <c>true</c> if the token is active; otherwise, <c>false</c>.
     /// </value>
     public bool IsActive => Json?.TryGetBoolean("active") ?? false;
+
+    /// <summary>
+    /// Gets the list of scopes associated to the token.
+    /// </summary>
+    /// <value>
+    /// The list of scopes associated to the token or an empty array if no <c>scope</c> claim is present.
+    /// </value>
+    public string[] Scopes => _scopes.Value;
+
+    /// <summary>
+    /// Gets the client identifier for the OAuth 2.0 client that requested the token.
+    /// </summary>
+    /// <value>
+    /// The client identifier for the OAuth 2.0 client that requested the token or null if the <c>client_id</c> claim is missing.
+    /// </value>
+    public string? ClientId => _clientId.Value;
+
+    /// <summary>
+    /// Gets the human-readable identifier for the resource owner who authorized the token.
+    /// </summary>
+    /// <value>
+    /// The human-readable identifier for the resource owner who authorized the token or null if the <c>username</c> claim is missing.
+    /// </value>
+    public string? UserName => _userName.Value;
+
+    /// <summary>
+    /// Gets the type of the token as defined in <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-5.1">section 5.1 of OAuth 2.0 (RFC6749)</a>.
+    /// </summary>
+    /// <value>
+    /// The type of the token as defined in <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-5.1">section 5.1 of OAuth 2.0 (RFC6749)</a> or null if the <c>token_type</c> claim is missing.
+    /// </value>
+    public string? TokenType => _tokenType.Value;
+
+    /// <summary>
+    /// Gets the time on or after which the token must not be accepted for processing.
+    /// </summary>
+    /// <value>
+    /// The expiration time of the token or null if the <c>exp</c> claim is missing.
+    /// </value>
+    public DateTimeOffset? Expiration => _expiration.Value;
+
+    /// <summary>
+    /// Gets the time when the token was issued.
+    /// </summary>
+    /// <value>
+    /// The issuance time of the token or null if the <c>iat</c> claim is missing.
+    /// </value>
+    public DateTimeOffset? IssuedAt => _issuedAt.Value;
+
+    /// <summary>
+    /// Gets the time before which the token must not be accepted for processing.
+    /// </summary>
+    /// <value>
+    /// The validity start time of the token or null if the <c>nbf</c> claim is missing.
+    /// </value>
+    public DateTimeOffset? NotBefore => _notBefore.Value;
+
+    /// <summary>
+    /// Gets the subject of the token. Usually a machine-readable identifier of the resource owner who authorized the token.
+    /// </summary>
+    /// <value>
+    /// The subject of the token or null if the <c>sub</c> claim is missing.
+    /// </value>
+    public string? Subject => _subject.Value;
+
+    /// <summary>
+    /// Gets the service-specific list of string identifiers representing the intended audience for the token.
+    /// </summary>
+    /// <value>
+    /// The service-specific list of string identifiers representing the intended audience for the token or an empty array if no <c>aud</c> claim is present.
+    /// </value>
+    public string[] Audiences => _audiences.Value;
+
+    /// <summary>
+    /// Gets the string representing the issuer of the token.
+    /// </summary>
+    /// <value>
+    /// The string representing the issuer of the token or null if the <c>iss</c> claim is missing.
+    /// </value>
+    public string? Issuer => _issuer.Value;
+
+    /// <summary>
+    /// Gets the string identifier for the token.
+    /// </summary>
+    /// <value>
+    /// The string identifier for the token or null if the <c>jti</c> claim is missing.
+    /// </value>
+    public string? JwtId => _jwtId.Value;
 
     /// <summary>
     /// Gets the claims.

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenIntrospectionTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenIntrospectionTests.cs
@@ -12,6 +12,8 @@ namespace Duende.IdentityModel.HttpClientExtensions;
 public class TokenIntrospectionTests
 {
     private const string Endpoint = "http://server/token";
+    private static readonly DateTimeOffset NotBeforeDate = new(year: 2016, month: 10, day: 7, hour: 7, minute: 21, second: 11, offset: TimeSpan.Zero);
+    private static readonly DateTimeOffset ExpirationDate = new(year: 2016, month: 10, day: 7, hour: 8, minute: 21, second: 11, offset: TimeSpan.Zero);
 
     [Fact]
     public async Task Http_request_should_have_correct_format()
@@ -80,6 +82,16 @@ public class TokenIntrospectionTests
             new("scope", "api2", ClaimValueTypes.String, "https://idsvr4"),
         };
         response.Claims.ShouldBe(expected, new ClaimComparer());
+        response.Scopes.ShouldBe(["api1", "api2"]);
+        response.ClientId.ShouldBe("client");
+        response.UserName.ShouldBeNull();
+        response.IssuedAt.ShouldBeNull();
+        response.NotBefore.ShouldBe(NotBeforeDate);
+        response.Expiration.ShouldBe(ExpirationDate);
+        response.Subject.ShouldBe("1");
+        response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+        response.Issuer.ShouldBe("https://idsvr4");
+        response.JwtId.ShouldBeNull();
     }
 
     [Fact]
@@ -118,6 +130,16 @@ public class TokenIntrospectionTests
             new("scope", "api2", ClaimValueTypes.String, "LOCAL AUTHORITY"),
         };
         response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+        response.Scopes.ShouldBe(["api1", "api2"]);
+        response.ClientId.ShouldBe("client");
+        response.UserName.ShouldBeNull();
+        response.IssuedAt.ShouldBeNull();
+        response.NotBefore.ShouldBe(NotBeforeDate);
+        response.Expiration.ShouldBe(ExpirationDate);
+        response.Subject.ShouldBe("1");
+        response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+        response.Issuer.ShouldBeNull();
+        response.JwtId.ShouldBeNull();
     }
 
     [Fact]
@@ -159,6 +181,16 @@ public class TokenIntrospectionTests
             new("scope", "api2", ClaimValueTypes.String, "https://idsvr4"),
         };
         response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+        response.Scopes.ShouldBe(["api1", "api2"]);
+        response.ClientId.ShouldBe("client");
+        response.UserName.ShouldBeNull();
+        response.IssuedAt.ShouldBeNull();
+        response.NotBefore.ShouldBe(NotBeforeDate);
+        response.Expiration.ShouldBe(ExpirationDate);
+        response.Subject.ShouldBe("1");
+        response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+        response.Issuer.ShouldBe("https://idsvr4");
+        response.JwtId.ShouldBeNull();
 
         // repeat
         response = await client.IntrospectTokenAsync(request);
@@ -168,6 +200,16 @@ public class TokenIntrospectionTests
         response.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
         response.IsActive.ShouldBeTrue();
         response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+        response.Scopes.ShouldBe(["api1", "api2"]);
+        response.ClientId.ShouldBe("client");
+        response.UserName.ShouldBeNull();
+        response.IssuedAt.ShouldBeNull();
+        response.NotBefore.ShouldBe(NotBeforeDate);
+        response.Expiration.ShouldBe(ExpirationDate);
+        response.Subject.ShouldBe("1");
+        response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+        response.Issuer.ShouldBe("https://idsvr4");
+        response.JwtId.ShouldBeNull();
     }
 
     [Fact]
@@ -276,6 +318,16 @@ public class TokenIntrospectionTests
             new("scope", "api2", ClaimValueTypes.String, "https://idsvr4")
         };
         response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+        response.Scopes.ShouldBe(["api1", "api2"]);
+        response.ClientId.ShouldBe("client");
+        response.UserName.ShouldBeNull();
+        response.IssuedAt.ShouldBeNull();
+        response.NotBefore.ShouldBe(NotBeforeDate);
+        response.Expiration.ShouldBe(ExpirationDate);
+        response.Subject.ShouldBe("1");
+        response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+        response.Issuer.ShouldBe("https://idsvr4");
+        response.JwtId.ShouldBeNull();
     }
 
     [Fact]

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -1283,12 +1283,12 @@ namespace Duende.IdentityModel.Client
         public System.DateTimeOffset? IssuedAt { get; }
         public string? Issuer { get; }
         public string? JwtId { get; }
+        public Duende.IdentityModel.Validation.ITokenIntrospectionJwtResponseValidator? JwtResponseValidator { get; set; }
         public System.DateTimeOffset? NotBefore { get; }
         public string[] Scopes { get; }
         public string? Subject { get; }
         public string? TokenType { get; }
         public string? UserName { get; }
-        public Duende.IdentityModel.Validation.ITokenIntrospectionJwtResponseValidator? JwtResponseValidator { get; set; }
         protected override System.Threading.Tasks.Task InitializeAsync(object? initializationData = null) { }
     }
     public class TokenRequest : Duende.IdentityModel.Client.ProtocolRequest

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -1275,8 +1275,19 @@ namespace Duende.IdentityModel.Client
     public class TokenIntrospectionResponse : Duende.IdentityModel.Client.ProtocolResponse
     {
         public TokenIntrospectionResponse() { }
+        public string[] Audiences { get; }
         public System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get; set; }
+        public string? ClientId { get; }
+        public System.DateTimeOffset? Expiration { get; }
         public bool IsActive { get; }
+        public System.DateTimeOffset? IssuedAt { get; }
+        public string? Issuer { get; }
+        public string? JwtId { get; }
+        public System.DateTimeOffset? NotBefore { get; }
+        public string[] Scopes { get; }
+        public string? Subject { get; }
+        public string? TokenType { get; }
+        public string? UserName { get; }
         public Duende.IdentityModel.Validation.ITokenIntrospectionJwtResponseValidator? JwtResponseValidator { get; set; }
         protected override System.Threading.Tasks.Task InitializeAsync(object? initializationData = null) { }
     }


### PR DESCRIPTION
As described by [RFC 7662 - OAuth 2.0 Token Introspection][1]

[1]: https://datatracker.ietf.org/doc/html/rfc7662

(Taking over https://github.com/IdentityModel/IdentityModel/pull/577 to the new repository, adapted to the new `Duende.IdentityModel` namespace.)
