### PR TITLE
Set appropriate actions permissions for build job.

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -61,6 +61,8 @@ void GenerateCiWorkflow(Component component)
         .Defaults().Run("bash", component.Name)
         .Job;
 
+    job.Permissions(actions: Permission.Read, contents: Permission.Read, checks: Permission.Write);
+
     job.TimeoutMinutes(15);
 
     job.Step()

--- a/.github/workflows/access-token-management-ci.yml
+++ b/.github/workflows/access-token-management-ci.yml
@@ -20,6 +20,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     defaults:
       run:
         shell: bash

--- a/.github/workflows/identity-model-ci.yml
+++ b/.github/workflows/identity-model-ci.yml
@@ -20,6 +20,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     defaults:
       run:
         shell: bash

--- a/.github/workflows/identity-model-oidc-client-ci.yml
+++ b/.github/workflows/identity-model-oidc-client-ci.yml
@@ -20,6 +20,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ignore-this-ci.yml
+++ b/.github/workflows/ignore-this-ci.yml
@@ -20,6 +20,10 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Sets the appropriate permissions for the GitHub token.

Needed to adjust for external contributed PRs and being able to write test reporter checks.