### PR TITLE
Fix HttpRequestMethod.Properties obsolete warning

### DIFF
--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DeviceAuthorizationExtensionsTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DeviceAuthorizationExtensionsTests.cs
@@ -39,8 +39,6 @@ namespace Duende.IdentityModel.HttpClientExtensions
             
             var headers = httpRequest.Headers;
             headers.Count().Should().Be(2);
-            
-            
         }
         
         [Fact]
@@ -56,7 +54,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var _ = await client.RequestDeviceAuthorizationAsync(request);
 
@@ -69,7 +67,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Count().Should().Be(3);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DiscoveryExtensionsTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DiscoveryExtensionsTests.cs
@@ -47,7 +47,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var response = await client.GetDiscoveryDocumentAsync(request);
 
@@ -61,7 +61,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Count().Should().Be(2);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DynamicClientRegistrationTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DynamicClientRegistrationTests.cs
@@ -30,7 +30,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var response = await client.RegisterClientAsync(request);
 
@@ -44,7 +44,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Count().Should().Be(2);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/HttpRequestMethodExtensions.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/HttpRequestMethodExtensions.cs
@@ -1,0 +1,17 @@
+﻿#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+
+namespace Duende.IdentityModel.HttpClientExtensions;
+
+internal static class HttpRequestMethodExtensions
+{
+    public static IDictionary<string, object> GetProperties(this HttpRequestMessage requestMessage)
+    {
+#if NETFRAMEWORK
+        return requestMessage.Properties;
+#else
+        return (IDictionary<string, object>)requestMessage.Options;
+#endif
+    }
+}

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/JsonWebKeyExtensionsTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/JsonWebKeyExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var response = await client.GetJsonWebKeySetAsync(request);
 
@@ -60,7 +60,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Count().Should().Be(2);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/PushedAuthorizationTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/PushedAuthorizationTests.cs
@@ -38,7 +38,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
                 State = "5678"
             };
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var response = await client.PushAuthorizationAsync(request);
 
@@ -52,7 +52,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Count().Should().Be(3);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenIntrospectionTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenIntrospectionTests.cs
@@ -28,7 +28,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             _ = await client.IntrospectTokenAsync(request);
 
@@ -42,7 +42,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
                 ["Accept"] = new[] { "application/json" },
                 ["custom"] = new[] { "custom" },
             });
-            httpRequest.Properties.Should().BeEquivalentTo(new Dictionary<string, string>
+            httpRequest.GetProperties().Should().BeEquivalentTo(new Dictionary<string, string>
             {
                 ["custom"] = "custom",
             });

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
@@ -43,7 +43,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var _ = await client.RequestTokenAsync(request);
             var httpRequest = handler.Request;
@@ -56,7 +56,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Count().Should().Be(3);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();
@@ -159,13 +159,13 @@ namespace Duende.IdentityModel.HttpClientExtensions
                 Scope = "scope"
             };
 
-            request.Properties.Add("foo", "bar");
+            request.GetProperties().Add("foo", "bar");
 
             var response = await _client.RequestClientCredentialsTokenAsync(request);
 
             response.IsError.Should().BeFalse();
 
-            var properties = _handler.Request.Properties;
+            var properties = _handler.Request.GetProperties();
             var foo = properties.First().Value as string;
             foo.Should().NotBeNull();
             foo.Should().Be("bar");

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRevocationExtensions.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRevocationExtensions.cs
@@ -27,7 +27,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var response = await client.RevokeTokenAsync(request);
 
@@ -41,7 +41,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Count().Should().Be(2);
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/UserInfoExtensionsTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/UserInfoExtensionsTests.cs
@@ -45,7 +45,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             };
 
             request.Headers.Add("custom", "custom");
-            request.Properties.Add("custom", "custom");
+            request.GetProperties().Add("custom", "custom");
 
             var response = await client.GetUserInfoAsync(request);
 
@@ -60,7 +60,7 @@ namespace Duende.IdentityModel.HttpClientExtensions
             headers.Should().Contain(h => h.Key == "custom" && h.Value.First() == "custom");
             headers.Should().Contain(h => h.Key == "Authorization" && h.Value.First() == "Bearer token");
 
-            var properties = httpRequest.Properties;
+            var properties = httpRequest.GetProperties();
             properties.Count.Should().Be(1);
 
             var prop = properties.First();


### PR DESCRIPTION
Add a small extension that has conditional compilation based on target framework to access .Options or .Properties accordingly.

Fixes #33

