### PR TITLE
Blazor sample fix

### DIFF
--- a/access-token-management/samples/BlazorServer/Plumbing/ServerSideTokenStore.cs
+++ b/access-token-management/samples/BlazorServer/Plumbing/ServerSideTokenStore.cs
@@ -13,7 +13,7 @@ namespace BlazorServer.Plumbing;
 /// </summary>
 public class ServerSideTokenStore : IUserTokenStore
 {
-    private readonly ConcurrentDictionary<string, UserToken> _tokens = new();
+    private static readonly ConcurrentDictionary<string, UserToken> _tokens = new();
 
     public Task<UserToken> GetTokenAsync(ClaimsPrincipal user, UserTokenRequestParameters? parameters = null)
     {


### PR DESCRIPTION
The server side token store is registered as scoped, so the underlying dictionary containing tokens needs to be static in our sample.

Possibly Related: #68 


