### PR TITLE
OidcClient - .NET 9 support

### DIFF
--- a/identity-model-oidc-client/README.md
+++ b/identity-model-oidc-client/README.md
@@ -1,11 +1,11 @@
-## About IdentityModel.OidcClient
+## About Duende.IdentityModel.OidcClient
 
-This repository contains several libraries for building OpenID Connect (OIDC) native
+This directory contains several libraries for building OpenID Connect (OIDC) native
 clients. The core `Duende.IdentityModel.OidcClient` library is a certified OIDC relying party and
 implements [RFC 8252](https://tools.ietf.org/html/rfc8252/), "OAuth 2.0 for native
 Applications". The `Duende.IdentityModel.OidcClient.Extensions` provides support for
 [DPoP](https://datatracker.ietf.org/doc/html/rfc9449) 
-extensions to IdentityModel.OidcClient for sender-constraining tokens.
+extensions to Duende.IdentityModel.OidcClient for sender-constraining tokens.
 
 ## Samples
 OidcClient targets .NET Standard, making it suitable for .NET and .NET

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/IdentityModel.OidcClient.Extensions.csproj
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/IdentityModel.OidcClient.Extensions.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>Duende.IdentityModel.OidcClient</RootNamespace>
     <AssemblyName>Duende.IdentityModel.OidcClient.Extensions</AssemblyName>
     <PackageId>Duende.IdentityModel.OidcClient.Extensions</PackageId>
     <PackageTags>OAuth2;OAuth 2.0;OpenID Connect;Security;Identity;IdentityServer;DPoP</PackageTags>
     <Description>DPoP extensions for IdentityModel.OidcClient</Description>
     <PackageReadmePath>README.md</PackageReadmePath>
-    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>Duende.IdentityModel.OidcClient</RootNamespace>
     <AssemblyName>Duende.IdentityModel.OidcClient</AssemblyName>
     <PackageId>Duende.IdentityModel.OidcClient</PackageId>

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/IdentityModel.OidcClient.Tests.csproj
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/IdentityModel.OidcClient.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>Duende.IdentityModel.OidcClient</RootNamespace>
     <AssemblyOriginatorKeyFile>../../../key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/identity-model/src/TrimmableAnalysis/TrimmableAnalysis.csproj
+++ b/identity-model/src/TrimmableAnalysis/TrimmableAnalysis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>


### PR DESCRIPTION
In OidcClient and its extensions, add .net 9 and drop .net 6 targets

**What issue does this PR address?**
#66 