### PR TITLE
fix(auth): restore singleton support for IUserTokenStore in Blazor Server

### DIFF
--- a/access-token-management/samples/BlazorServer/HostingExtensions.cs
+++ b/access-token-management/samples/BlazorServer/HostingExtensions.cs
@@ -53,7 +53,7 @@ public static class HostingExtensions
 
         // adds access token management
         builder.Services.AddOpenIdConnectAccessTokenManagement()
-            .AddBlazorServerAccessTokenManagement<ServerSideTokenStore>();
+            .AddBlazorServerAccessTokenManagement<ServerSideTokenStore>(ServiceLifetime.Singleton);
         
         // register events to customize authentication handlers
         builder.Services.AddTransient<CookieEvents>();

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
@@ -59,10 +59,18 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
     /// Server requires an IUserTokenStore because the default token store
     /// relies on cookies, which are not present when streaming updates over a
     /// blazor circuit. </typeparam>
-    public static IServiceCollection AddBlazorServerAccessTokenManagement<TTokenStore>(this IServiceCollection services)
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <param name="tokenStoreLifetime">The lifetime associated with the <see cref="!:TTokenStore"/> implementation.</param>
+    public static IServiceCollection AddBlazorServerAccessTokenManagement<TTokenStore>(
+        this IServiceCollection services,
+        ServiceLifetime tokenStoreLifetime = ServiceLifetime.Scoped)
         where TTokenStore : class, IUserTokenStore
     {
-        services.AddScoped<IUserTokenStore, TTokenStore>();
+        services.Add(new ServiceDescriptor(
+            typeof(IUserTokenStore), 
+            typeof(TTokenStore), 
+            tokenStoreLifetime));
+
         services.AddScoped<IUserAccessor, BlazorServerUserAccessor>();
         services.AddCircuitServicesAccessor();
         services.AddHttpContextAccessor(); // For SSR


### PR DESCRIPTION
Fix regression introduced in v3.1.0 where IUserTokenStore was changed from singleton to scoped registration. Add configurable lifetime parameter to support both singleton and scoped implementations, maintaining backward compatibility with previous versions.

This has been tested on my project using the singleton parameter.
