### PR TITLE
Remove Install Sectigo CodeSiging CA certificates step

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -79,8 +79,6 @@ void GenerateCiWorkflow(Component component)
         job.StepTestAndReport(component.Name, testProject);
     }
 
-    job.StepInstallCACerts();
-
     job.StepToolRestore();
 
     foreach (var project in component.Projects)
@@ -130,8 +128,6 @@ void GenerateReleaseWorkflow(Component component)
 git config --global user.name ""Duende Software GitHub Bot""
 git tag -a {component.TagPrefix}-{contexts.Event.Input.Version} -m ""Release v{contexts.Event.Input.Version}""
 git push origin {component.TagPrefix}-{contexts.Event.Input.Version}");
-
-    tagJob.StepInstallCACerts();
 
     foreach (var project in component.Projects)
     {
@@ -219,18 +215,6 @@ public static class StepExtensions
                 ("fail-on-error", "true"),
                 ("fail-on-empty", "true"));
     }
-
-    // These intermediate certificates are required for signing and are not installed on the GitHub runners by default.
-    public static void StepInstallCACerts(this Job job)
-        => job.Step()
-            .Name("Install Sectigo CodeSiging CA certificates") 
-            .WorkingDirectory(".github/workflows")
-            .Run("""
-                 sudo apt-get update
-                 sudo apt-get install -y ca-certificates
-                 sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-                 sudo update-ca-certificates
-                 """);
 
     public static void StepToolRestore(this Job job)
         => job.Step()

--- a/.github/workflows/access-token-management-ci.yml
+++ b/.github/workflows/access-token-management-ci.yml
@@ -53,13 +53,6 @@ jobs:
         reporter: dotnet-trx
         fail-on-error: true
         fail-on-empty: true
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Tool restore
       run: dotnet tool restore
     - name: Pack AccessTokenManagement

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -41,13 +41,6 @@ jobs:
         git config --global user.name "Duende Software GitHub Bot"
         git tag -a atm-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin atm-${{ github.event.inputs.version }}
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Pack AccessTokenManagement
       run: dotnet pack -c Release src/AccessTokenManagement -o artifacts
     - name: Pack AccessTokenManagement.OpenIdConnect

--- a/.github/workflows/identity-model-ci.yml
+++ b/.github/workflows/identity-model-ci.yml
@@ -53,13 +53,6 @@ jobs:
         reporter: dotnet-trx
         fail-on-error: true
         fail-on-empty: true
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Tool restore
       run: dotnet tool restore
     - name: Pack IdentityModel

--- a/.github/workflows/identity-model-oidc-client-ci.yml
+++ b/.github/workflows/identity-model-oidc-client-ci.yml
@@ -53,13 +53,6 @@ jobs:
         reporter: dotnet-trx
         fail-on-error: true
         fail-on-empty: true
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Tool restore
       run: dotnet tool restore
     - name: Pack IdentityModel.OidcClient

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -41,13 +41,6 @@ jobs:
         git config --global user.name "Duende Software GitHub Bot"
         git tag -a imoc-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin imoc-${{ github.event.inputs.version }}
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Pack IdentityModel.OidcClient
       run: dotnet pack -c Release src/IdentityModel.OidcClient -o artifacts
     - name: Pack IdentityModel.OidcClient.Extensions

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -41,13 +41,6 @@ jobs:
         git config --global user.name "Duende Software GitHub Bot"
         git tag -a im-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin im-${{ github.event.inputs.version }}
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Pack IdentityModel
       run: dotnet pack -c Release src/IdentityModel -o artifacts
     - name: Tool restore

--- a/.github/workflows/ignore-this-ci.yml
+++ b/.github/workflows/ignore-this-ci.yml
@@ -53,13 +53,6 @@ jobs:
         reporter: dotnet-trx
         fail-on-error: true
         fail-on-empty: true
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Tool restore
       run: dotnet tool restore
     - name: Pack IgnoreThis

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -41,13 +41,6 @@ jobs:
         git config --global user.name "Duende Software GitHub Bot"
         git tag -a it-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin it-${{ github.event.inputs.version }}
-    - name: Install Sectigo CodeSiging CA certificates
-      run: |-
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates
-        sudo cp SectigoPublicCodeSigningRootCrossAAA.crt /usr/local/share/ca-certificates/
-        sudo update-ca-certificates
-      working-directory: .github/workflows
     - name: Pack IgnoreThis
       run: dotnet pack -c Release src/IgnoreThis -o artifacts
     - name: Tool restore


### PR DESCRIPTION
**What issue does this PR address?**

No longer need to install the sectigo code signing CA for signing nuget package.


