### PR TITLE
Fix typo in environment variable key for DOTNET_NOLOGO

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -182,7 +182,7 @@ public static class StepExtensions
 {
     public static void EnvDefaults(this Workflow workflow)
         => workflow.Env(
-            ("DOTNETT_NOLOGO", "true"),
+            ("DOTNET_NOLOGO", "true"),
             ("DOTNET_CLI_TELEMETRY_OPTOUT", "true"));
 
     public static void StepSetupDotNet(this Job job)

--- a/.github/workflows/access-token-management-ci.yml
+++ b/.github/workflows/access-token-management-ci.yml
@@ -14,7 +14,7 @@ on:
     - access-token-management/**
     - Directory.Packages.props
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   build:

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: '0.0.0'
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   tag:

--- a/.github/workflows/identity-model-ci.yml
+++ b/.github/workflows/identity-model-ci.yml
@@ -14,7 +14,7 @@ on:
     - identity-model/**
     - Directory.Packages.props
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   build:

--- a/.github/workflows/identity-model-oidc-client-ci.yml
+++ b/.github/workflows/identity-model-oidc-client-ci.yml
@@ -14,7 +14,7 @@ on:
     - identity-model-oidc-client/**
     - Directory.Packages.props
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   build:

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: '0.0.0'
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   tag:

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: '0.0.0'
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   tag:

--- a/.github/workflows/ignore-this-ci.yml
+++ b/.github/workflows/ignore-this-ci.yml
@@ -14,7 +14,7 @@ on:
     - ignore-this/**
     - Directory.Packages.props
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   build:

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: '0.0.0'
 env:
-  DOTNETT_NOLOGO: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   tag:


### PR DESCRIPTION
Corrects the environment variable key from "DOTNETT_NOLOGO" to "DOTNET_NOLOGO" in the workflow setup. This ensures proper configuration and eliminates potential errors caused by the typo.

https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo


