### PR TITLE
atm - Make sure sync method of access token handler is not invoked

### DIFF
--- a/access-token-management/src/AccessTokenManagement/AccessTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement/AccessTokenHandler.cs
@@ -41,6 +41,13 @@ public abstract class AccessTokenHandler : DelegatingHandler
     protected abstract Task<ClientCredentialsToken> GetAccessTokenAsync(bool forceRenewal, CancellationToken cancellationToken);
 
     /// <inheritdoc/>
+    protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        throw new NotSupportedException(
+            "The (synchronous) Send() method is not supported. Please use the async SendAsync variant. ");
+    }
+
+    /// <inheritdoc/>
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         await SetTokenAsync(request, forceRenewal: false, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
**What issue does this PR address?**

The Send() method of the AccessTokenHandler now fails with a NotSupportedException, rather than fail silently. 

The synchronous Send() method of the access token handler was never implemented. Calling it would cause it to do nothing. Unfortunately we can't implement this method, because we're calling into other asynchronous code. We also can't implement it by calling .GetAwaiter().GetResult() as this might have many negative side effects such as deadlocks. 

The origin of this issue is that the SendAsync() was already present in .Net core 1.0 but the Send method was introduced later. 

fixes: https://github.com/DuendeSoftware/foss/issues/28