### PR TITLE
build - don't use pull_request_target anymore

### DIFF
--- a/.github/workflow-gen/Properties/launchSettings.json
+++ b/.github/workflow-gen/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "workflow-gen": {
+      "commandName": "Project",
+      "workingDirectory": "$(ProjectDir)"
+    }
+  }
+}

--- a/.github/workflows/access-token-management-ci.yml
+++ b/.github/workflows/access-token-management-ci.yml
@@ -8,7 +8,7 @@ on:
     - .github/workflows/access-token-management-**
     - access-token-management/**
     - Directory.Packages.props
-  pull_request_target:
+  pull_request:
     paths:
     - .github/workflows/access-token-management-**
     - access-token-management/**
@@ -45,7 +45,7 @@ jobs:
     - name: Test - AccessTokenManagement.Tests
       run: dotnet test -c Release test/AccessTokenManagement.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - AccessTokenManagement.Tests
-      if: success() || failure()
+      if: github.event == 'push' && (success() || failure())
       uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - AccessTokenManagement.Tests
@@ -60,6 +60,7 @@ jobs:
     - name: Pack AccessTokenManagement.OpenIdConnect
       run: dotnet pack -c Release src/AccessTokenManagement.OpenIdConnect -o artifacts
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/identity-model-ci.yml
+++ b/.github/workflows/identity-model-ci.yml
@@ -8,7 +8,7 @@ on:
     - .github/workflows/identity-model-**
     - identity-model/**
     - Directory.Packages.props
-  pull_request_target:
+  pull_request:
     paths:
     - .github/workflows/identity-model-**
     - identity-model/**
@@ -45,7 +45,7 @@ jobs:
     - name: Test - IdentityModel.Tests
       run: dotnet test -c Release test/IdentityModel.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - IdentityModel.Tests
-      if: success() || failure()
+      if: github.event == 'push' && (success() || failure())
       uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - IdentityModel.Tests
@@ -58,6 +58,7 @@ jobs:
     - name: Pack IdentityModel
       run: dotnet pack -c Release src/IdentityModel -o artifacts
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/identity-model-oidc-client-ci.yml
+++ b/.github/workflows/identity-model-oidc-client-ci.yml
@@ -8,7 +8,7 @@ on:
     - .github/workflows/identity-model-oidc-client-**
     - identity-model-oidc-client/**
     - Directory.Packages.props
-  pull_request_target:
+  pull_request:
     paths:
     - .github/workflows/identity-model-oidc-client-**
     - identity-model-oidc-client/**
@@ -45,7 +45,7 @@ jobs:
     - name: Test - IdentityModel.OidcClient.Tests
       run: dotnet test -c Release test/IdentityModel.OidcClient.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - IdentityModel.OidcClient.Tests
-      if: success() || failure()
+      if: github.event == 'push' && (success() || failure())
       uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - IdentityModel.OidcClient.Tests
@@ -60,6 +60,7 @@ jobs:
     - name: Pack IdentityModel.OidcClient.Extensions
       run: dotnet pack -c Release src/IdentityModel.OidcClient.Extensions -o artifacts
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -46,6 +46,7 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/ignore-this-ci.yml
+++ b/.github/workflows/ignore-this-ci.yml
@@ -8,7 +8,7 @@ on:
     - .github/workflows/ignore-this-**
     - ignore-this/**
     - Directory.Packages.props
-  pull_request_target:
+  pull_request:
     paths:
     - .github/workflows/ignore-this-**
     - ignore-this/**
@@ -45,7 +45,7 @@ jobs:
     - name: Test - IgnoreThis.Tests
       run: dotnet test -c Release test/IgnoreThis.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report - IgnoreThis.Tests
-      if: success() || failure()
+      if: github.event == 'push' && (success() || failure())
       uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: Test Report - IgnoreThis.Tests
@@ -58,6 +58,7 @@ jobs:
     - name: Pack IgnoreThis
       run: dotnet pack -c Release src/IgnoreThis -o artifacts
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -46,6 +46,7 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Sign packages
+      if: github.event == 'push'
       run: |-
         for file in artifacts/*.nupkg; do
            dotnet NuGetKeyVaultSignTool sign "$file" --file-digest sha256 --timestamp-rfc3161 http://timestamp.digicert.com --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} --azure-key-vault-certificate NuGetPackageSigning


### PR DESCRIPTION
**What issue does this PR address?**
The build no longer uses pull_request_target as this just compiles main, not the target branch. 

Previously, the build used pull_request_target. Effectively, this means that the entire context (including which code to build) was pointing to the target of the PR (likely main). This means it wasn't building anything in the PR, but actually building main (not very useful in a PR workflow)

How does it work?
Builds / pr's from contributors are run trusted and can access security tokens needed for signing. If you create a branch in the DuendeSoftware repo, then you'll automatically get a CI build for this. You can (must) create a PR for this to get it merged. When you create a PR, the build script will detect that there is still a branch for it and will built it normally (skip the PR build).

Builds from PR's created from external contributors (which have to originate from a different fork) will NOT run with security tokens, so artifacts will not be signed / pushed.

