### PR TITLE
Fix HttpClientExtensions to dispose of HttpResponseMessage when it goes out of scope (Migrate IdentityModel PR 598)

### DIFF
--- a/identity-model/src/IdentityModel/Client/HttpClientBackchannelAuthenticationExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientBackchannelAuthenticationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Internal;
@@ -50,10 +50,10 @@ public static class HttpClientBackchannelAuthenticationExtensions
         clone.Method = HttpMethod.Post;
         clone.Prepare();
                         
-        HttpResponseMessage response;
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<BackchannelAuthenticationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -63,7 +63,5 @@ public static class HttpClientBackchannelAuthenticationExtensions
         {
             return ProtocolResponse.FromException<BackchannelAuthenticationResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<BackchannelAuthenticationResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientDeviceFlowExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientDeviceFlowExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Internal;
@@ -32,10 +32,10 @@ public static class HttpClientDeviceFlowExtensions
             clone.Content = new FormUrlEncodedContent(new List<KeyValuePair<string, string>>());
         }
 
-        HttpResponseMessage response;
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<DeviceAuthorizationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -45,7 +45,5 @@ public static class HttpClientDeviceFlowExtensions
         {
             return ProtocolResponse.FromException<DeviceAuthorizationResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<DeviceAuthorizationResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientDiscoveryExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientDiscoveryExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Internal;
@@ -104,17 +104,14 @@ public static class HttpClientDiscoveryExtensions
                         {
                             return ProtocolResponse.FromException<DiscoveryDocumentResponse>(jwkResponse.Exception, jwkResponse.Error);
                         }
-                        else if(jwkResponse.HttpResponse != null)
+                        if(jwkResponse.HttpResponse != null)
                         {
                             return await ProtocolResponse.FromHttpResponseAsync<DiscoveryDocumentResponse>(jwkResponse.HttpResponse, $"Error connecting to {jwkUrl}: {jwkResponse.HttpErrorReason}").ConfigureAwait();
                         }
                         // If IsError is true, but we have neither an Exception nor an HttpResponse, something very weird is going on
                         // I don't think it is actually possible for this to occur, but just in case...
-                        else
-                        {
-                            return ProtocolResponse.FromException<DiscoveryDocumentResponse>(
-                                new ArgumentNullException(nameof(jwkResponse.HttpResponse)), $"Unknown error retrieving JWKS - neither an exception nor an HttpResponse is available");
-                        }
+                        return ProtocolResponse.FromException<DiscoveryDocumentResponse>(
+                            new ArgumentNullException(nameof(jwkResponse.HttpResponse)), $"Unknown error retrieving JWKS - neither an exception nor an HttpResponse is available");
                     }
 
                     disco.KeySet = jwkResponse.KeySet;

--- a/identity-model/src/IdentityModel/Client/HttpClientDynamicRegistrationExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientDynamicRegistrationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Text;
@@ -35,11 +35,11 @@ public static class HttpClientDynamicRegistrationExtensions
         {
             clone.SetBearerToken(request.Token!);
         }
-
-        HttpResponseMessage response;
+ 
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<DynamicClientRegistrationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -49,7 +49,5 @@ public static class HttpClientDynamicRegistrationExtensions
         {
             return ProtocolResponse.FromException<DynamicClientRegistrationResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<DynamicClientRegistrationResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientJsonWebKeySetExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientJsonWebKeySetExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Net.Http.Headers;
@@ -40,17 +40,16 @@ public static class HttpClientJsonWebKeySetExtensions
         clone.Method = HttpMethod.Get;
         clone.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/jwk-set+json"));
         clone.Prepare();
-
-        HttpResponseMessage response;
-
+    
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
-
+            using var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
             if (!response.IsSuccessStatusCode)
             {
                 return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response, $"Error connecting to {clone.RequestUri!.AbsoluteUri}: {response.ReasonPhrase}").ConfigureAwait();
             }
+            return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response).ConfigureAwait();
+
         }
         catch (OperationCanceledException)
         {
@@ -60,7 +59,5 @@ public static class HttpClientJsonWebKeySetExtensions
         {
             return ProtocolResponse.FromException<JsonWebKeySetResponse>(ex, $"Error connecting to {clone.RequestUri!.AbsoluteUri}. {ex.Message}.");
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<JsonWebKeySetResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientPushedAuthorizationExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientPushedAuthorizationExtensions.cs
@@ -68,21 +68,19 @@ public static class HttpClientPushedAuthorizationExtensions
     {
         request.Prepare();
         request.Method = HttpMethod.Post;
-            
-        HttpResponseMessage response;
+
         try
         {
-            response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<PushedAuthorizationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
-		{
+        {
             throw;
-		}
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<PushedAuthorizationResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<PushedAuthorizationResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientTokenIntrospectionExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientTokenIntrospectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Internal;
@@ -25,11 +25,11 @@ public static class HttpClientTokenIntrospectionExtensions
         clone.Parameters.AddRequired(OidcConstants.TokenIntrospectionRequest.Token, request.Token);
         clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
         clone.Prepare();
-
-        HttpResponseMessage response;
+        
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<TokenIntrospectionResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -39,7 +39,5 @@ public static class HttpClientTokenIntrospectionExtensions
         {
             return ProtocolResponse.FromException<TokenIntrospectionResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<TokenIntrospectionResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientTokenRequestExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientTokenRequestExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Internal;
@@ -208,25 +208,24 @@ public static class HttpClientTokenRequestExtensions
         return await client.RequestTokenAsync(request, cancellationToken).ConfigureAwait();
     }
 
-    internal static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken = default)
+    private static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, ProtocolRequest request,
+        CancellationToken cancellationToken = default)
     {
         request.Prepare();
         request.Method = HttpMethod.Post;
-            
-        HttpResponseMessage response;
+
         try
         {
-            response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<TokenResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
-		{
+        {
             throw;
-		}
+        }
         catch (Exception ex)
         {
             return ProtocolResponse.FromException<TokenResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<TokenResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientTokenRevocationExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientTokenRevocationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Internal;
@@ -26,10 +26,10 @@ public static class HttpClientTokenRevocationExtensions
         clone.Parameters.AddOptional(OidcConstants.TokenIntrospectionRequest.TokenTypeHint, request.TokenTypeHint);
         clone.Prepare();
 
-        HttpResponseMessage response;
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            return await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response).ConfigureAwait();
         }
         catch (OperationCanceledException)
         {
@@ -39,7 +39,5 @@ public static class HttpClientTokenRevocationExtensions
         {
             return ProtocolResponse.FromException<TokenRevocationResponse>(ex);
         }
-
-        return await ProtocolResponse.FromHttpResponseAsync<TokenRevocationResponse>(response).ConfigureAwait();
     }
 }

--- a/identity-model/src/IdentityModel/Client/HttpClientUserInfoExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientUserInfoExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Internal;
@@ -27,10 +27,13 @@ public static class HttpClientUserInfoExtensions
         clone.SetBearerToken(request.Token!);
         clone.Prepare();
 
-        HttpResponseMessage response;
         try
         {
-            response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            using var response = await client.SendAsync(clone, cancellationToken).ConfigureAwait();
+            // response.Content can be null in net462 and net471
+            var skipJsonParsing = response.Content?.Headers.ContentType?.MediaType != "application/json";
+            return await ProtocolResponse.FromHttpResponseAsync<UserInfoResponse>(response, skipJson: skipJsonParsing).ConfigureAwait();
+
         }
         catch (OperationCanceledException)
         {
@@ -40,9 +43,5 @@ public static class HttpClientUserInfoExtensions
         {
             return ProtocolResponse.FromException<UserInfoResponse>(ex);
         }
-
-        // response.Content can be null in net462 and net471
-        var skipJsonParsing = response.Content?.Headers.ContentType?.MediaType != "application/json";
-        return await ProtocolResponse.FromHttpResponseAsync<UserInfoResponse>(response, skipJson: skipJsonParsing).ConfigureAwait();
     }
 }

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DiscoveryExtensionsTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DiscoveryExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Text.Json;
@@ -344,7 +344,6 @@ namespace Duende.IdentityModel.HttpClientExtensions
                         Content = new StringContent("not_json")
                     };
                 }
-
                 return response;
             });
 


### PR DESCRIPTION
Migrates [this PR](https://github.com/IdentityModel/IdentityModel/pull/598) from Identity Model repo by @gizmohd

