### PR TITLE
Add properties to TokenIntrospectionResponse for all optional claims defined in RFC 7662 (OAuth 2.0 Token Introspection) (Import IdentityModel PR 577)

### DIFF
--- a/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/TokenIntrospectionResponse.cs
@@ -1,17 +1,57 @@
 ﻿// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Globalization;
 using System.Security.Claims;
 using System.Text.Json;
 
 namespace Duende.IdentityModel.Client;
 
 /// <summary>
-/// Models an OAuth 2.0 introspection response
+/// Models an OAuth 2.0 introspection response as defined by <a href="https://datatracker.ietf.org/doc/html/rfc7662">RFC 7662 - OAuth 2.0 Token Introspection</a>
 /// </summary>
 /// <seealso cref="ProtocolResponse" />
 public class TokenIntrospectionResponse : ProtocolResponse
 {
+    private readonly Lazy<string[]> _scopes;
+    private readonly Lazy<string?> _clientId;
+    private readonly Lazy<string?> _userName;
+    private readonly Lazy<string?> _tokenType;
+    private readonly Lazy<DateTimeOffset?> _expiration;
+    private readonly Lazy<DateTimeOffset?> _issuedAt;
+    private readonly Lazy<DateTimeOffset?> _notBefore;
+    private readonly Lazy<string?> _subject;
+    private readonly Lazy<string[]> _audiences;
+    private readonly Lazy<string?> _issuer;
+    private readonly Lazy<string?> _jwtId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TokenIntrospectionResponse"/> class.
+    /// </summary>
+    public TokenIntrospectionResponse()
+    {
+        _scopes = new Lazy<string[]>(() => Claims.Where(c => c.Type == JwtClaimTypes.Scope).Select(c => c.Value).ToArray());
+        _clientId = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.ClientId)?.Value);
+        _userName = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == "username")?.Value);
+        _tokenType = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == "token_type")?.Value);
+        _expiration = new Lazy<DateTimeOffset?>(() => GetTime(JwtClaimTypes.Expiration));
+        _issuedAt = new Lazy<DateTimeOffset?>(() => GetTime(JwtClaimTypes.IssuedAt));
+        _notBefore = new Lazy<DateTimeOffset?>(() => GetTime(JwtClaimTypes.NotBefore));
+        _subject = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject)?.Value);
+        _audiences = new Lazy<string[]>(() => Claims.Where(c => c.Type == JwtClaimTypes.Audience).Select(c => c.Value).ToArray());
+        _issuer = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.Issuer)?.Value);
+        _jwtId = new Lazy<string?>(() => Claims.FirstOrDefault(c => c.Type == JwtClaimTypes.JwtId)?.Value);
+    }
+
+    private DateTimeOffset? GetTime(string claimType)
+    {
+        var claimValue = Claims.FirstOrDefault(e => e.Type == claimType)?.Value;
+        if (claimValue == null) return null;
+
+        var seconds = long.Parse(claimValue, NumberStyles.AllowLeadingSign, NumberFormatInfo.InvariantInfo);
+        return DateTimeOffset.FromUnixTimeSeconds(seconds);
+    }
+
     /// <summary>
     /// Allows to initialize instance specific data.
     /// </summary>
@@ -68,6 +108,94 @@ public class TokenIntrospectionResponse : ProtocolResponse
     ///   <c>true</c> if the token is active; otherwise, <c>false</c>.
     /// </value>
     public bool IsActive => Json?.TryGetBoolean("active") ?? false;
+
+    /// <summary>
+    /// Gets the list of scopes associated to the token.
+    /// </summary>
+    /// <value>
+    /// The list of scopes associated to the token or an empty array if no <c>scope</c> claim is present.
+    /// </value>
+    public string[] Scopes => _scopes.Value;
+
+    /// <summary>
+    /// Gets the client identifier for the OAuth 2.0 client that requested the token.
+    /// </summary>
+    /// <value>
+    /// The client identifier for the OAuth 2.0 client that requested the token or null if the <c>client_id</c> claim is missing.
+    /// </value>
+    public string? ClientId => _clientId.Value;
+
+    /// <summary>
+    /// Gets the human-readable identifier for the resource owner who authorized the token.
+    /// </summary>
+    /// <value>
+    /// The human-readable identifier for the resource owner who authorized the token or null if the <c>username</c> claim is missing.
+    /// </value>
+    public string? UserName => _userName.Value;
+
+    /// <summary>
+    /// Gets the type of the token as defined in <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-5.1">section 5.1 of OAuth 2.0 (RFC6749)</a>.
+    /// </summary>
+    /// <value>
+    /// The type of the token as defined in <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-5.1">section 5.1 of OAuth 2.0 (RFC6749)</a> or null if the <c>token_type</c> claim is missing.
+    /// </value>
+    public string? TokenType => _tokenType.Value;
+
+    /// <summary>
+    /// Gets the time on or after which the token must not be accepted for processing.
+    /// </summary>
+    /// <value>
+    /// The expiration time of the token or null if the <c>exp</c> claim is missing.
+    /// </value>
+    public DateTimeOffset? Expiration => _expiration.Value;
+
+    /// <summary>
+    /// Gets the time when the token was issued.
+    /// </summary>
+    /// <value>
+    /// The issuance time of the token or null if the <c>iat</c> claim is missing.
+    /// </value>
+    public DateTimeOffset? IssuedAt => _issuedAt.Value;
+
+    /// <summary>
+    /// Gets the time before which the token must not be accepted for processing.
+    /// </summary>
+    /// <value>
+    /// The validity start time of the token or null if the <c>nbf</c> claim is missing.
+    /// </value>
+    public DateTimeOffset? NotBefore => _notBefore.Value;
+
+    /// <summary>
+    /// Gets the subject of the token. Usually a machine-readable identifier of the resource owner who authorized the token.
+    /// </summary>
+    /// <value>
+    /// The subject of the token or null if the <c>sub</c> claim is missing.
+    /// </value>
+    public string? Subject => _subject.Value;
+
+    /// <summary>
+    /// Gets the service-specific list of string identifiers representing the intended audience for the token.
+    /// </summary>
+    /// <value>
+    /// The service-specific list of string identifiers representing the intended audience for the token or an empty array if no <c>aud</c> claim is present.
+    /// </value>
+    public string[] Audiences => _audiences.Value;
+
+    /// <summary>
+    /// Gets the string representing the issuer of the token.
+    /// </summary>
+    /// <value>
+    /// The string representing the issuer of the token or null if the <c>iss</c> claim is missing.
+    /// </value>
+    public string? Issuer => _issuer.Value;
+
+    /// <summary>
+    /// Gets the string identifier for the token.
+    /// </summary>
+    /// <value>
+    /// The string identifier for the token or null if the <c>jti</c> claim is missing.
+    /// </value>
+    public string? JwtId => _jwtId.Value;
 
     /// <summary>
     /// Gets the claims.

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenIntrospectionTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenIntrospectionTests.cs
@@ -6,7 +6,6 @@ using System.Security.Claims;
 using System.Text.Json;
 using Duende.IdentityModel.Client;
 using Duende.IdentityModel.Infrastructure;
-using Shouldly;
 
 namespace Duende.IdentityModel.HttpClientExtensions
 {
@@ -81,6 +80,16 @@ namespace Duende.IdentityModel.HttpClientExtensions
                 new("scope", "api2", ClaimValueTypes.String, "https://idsvr4"),
             };
             response.Claims.ShouldBe(expected, new ClaimComparer());
+            response.Scopes.ShouldBe(["api1", "api2"]);
+            response.ClientId.ShouldBe("client");
+            response.UserName.ShouldBeNull();
+            response.IssuedAt.ShouldBeNull();
+            response.NotBefore.ShouldBe(new DateTimeOffset(2016,  10, 7, 7, 21, 11, TimeSpan.FromHours(0)));
+            response.Expiration.ShouldBe(new DateTimeOffset(2016, 10, 7, 8, 21, 11, TimeSpan.FromHours(0)));
+            response.Subject.ShouldBe("1");
+            response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+            response.Issuer.ShouldBe("https://idsvr4");
+            response.JwtId.ShouldBeNull();
         }
 
         [Fact]
@@ -119,6 +128,16 @@ namespace Duende.IdentityModel.HttpClientExtensions
                 new("scope", "api2", ClaimValueTypes.String, "LOCAL AUTHORITY"),
             };
             response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+            response.Scopes.ShouldBe(["api1", "api2"]);
+            response.ClientId.ShouldBe("client");
+            response.UserName.ShouldBeNull();
+            response.IssuedAt.ShouldBeNull();
+            response.NotBefore.ShouldBe(new DateTimeOffset(2016,  10, 7, 7, 21, 11, TimeSpan.FromHours(0)));
+            response.Expiration.ShouldBe(new DateTimeOffset(2016, 10, 7, 8, 21, 11, TimeSpan.FromHours(0)));
+            response.Subject.ShouldBe("1");
+            response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+            response.Issuer.ShouldBeNull();
+            response.JwtId.ShouldBeNull();
         }
 
         [Fact]
@@ -160,6 +179,16 @@ namespace Duende.IdentityModel.HttpClientExtensions
                 new("scope", "api2", ClaimValueTypes.String, "https://idsvr4"),
             };
             response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+            response.Scopes.ShouldBe(["api1", "api2"]);
+            response.ClientId.ShouldBe("client");
+            response.UserName.ShouldBeNull();
+            response.IssuedAt.ShouldBeNull();
+            response.NotBefore.ShouldBe(new DateTimeOffset(2016,  10, 7, 7, 21, 11, TimeSpan.FromHours(0)));
+            response.Expiration.ShouldBe(new DateTimeOffset(2016, 10, 7, 8, 21, 11, TimeSpan.FromHours(0)));
+            response.Subject.ShouldBe("1");
+            response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+            response.Issuer.ShouldBe("https://idsvr4");
+            response.JwtId.ShouldBeNull();
 
             // repeat
             response = await client.IntrospectTokenAsync(request);
@@ -169,6 +198,16 @@ namespace Duende.IdentityModel.HttpClientExtensions
             response.HttpStatusCode.ShouldBe(HttpStatusCode.OK);
             response.IsActive.ShouldBeTrue();
             response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+            response.Scopes.ShouldBe(["api1", "api2"]);
+            response.ClientId.ShouldBe("client");
+            response.UserName.ShouldBeNull();
+            response.IssuedAt.ShouldBeNull();
+            response.NotBefore.ShouldBe(new DateTimeOffset(2016,  10, 7, 7, 21, 11, TimeSpan.FromHours(0)));
+            response.Expiration.ShouldBe(new DateTimeOffset(2016, 10, 7, 8, 21, 11, TimeSpan.FromHours(0)));
+            response.Subject.ShouldBe("1");
+            response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+            response.Issuer.ShouldBe("https://idsvr4");
+            response.JwtId.ShouldBeNull();
         }
 
         [Fact]
@@ -277,6 +316,16 @@ namespace Duende.IdentityModel.HttpClientExtensions
                 new("scope", "api2", ClaimValueTypes.String, "https://idsvr4")
             };
             response.Claims.ShouldBe(expectedClaims, new ClaimComparer());
+            response.Scopes.ShouldBe(["api1", "api2"]);
+            response.ClientId.ShouldBe("client");
+            response.UserName.ShouldBeNull();
+            response.IssuedAt.ShouldBeNull();
+            response.NotBefore.ShouldBe(new DateTimeOffset(2016,  10, 7, 7, 21, 11, TimeSpan.FromHours(0)));
+            response.Expiration.ShouldBe(new DateTimeOffset(2016, 10, 7, 8, 21, 11, TimeSpan.FromHours(0)));
+            response.Subject.ShouldBe("1");
+            response.Audiences.ShouldBe(["https://idsvr4/resources", "api1"]);
+            response.Issuer.ShouldBe("https://idsvr4");
+            response.JwtId.ShouldBeNull();
         }
 
         [Fact]

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -1248,8 +1248,19 @@ namespace Duende.IdentityModel.Client
     public class TokenIntrospectionResponse : Duende.IdentityModel.Client.ProtocolResponse
     {
         public TokenIntrospectionResponse() { }
+        public string[] Audiences { get; }
         public System.Collections.Generic.IEnumerable<System.Security.Claims.Claim> Claims { get; set; }
+        public string? ClientId { get; }
+        public System.DateTimeOffset? Expiration { get; }
         public bool IsActive { get; }
+        public System.DateTimeOffset? IssuedAt { get; }
+        public string? Issuer { get; }
+        public string? JwtId { get; }
+        public System.DateTimeOffset? NotBefore { get; }
+        public string[] Scopes { get; }
+        public string? Subject { get; }
+        public string? TokenType { get; }
+        public string? UserName { get; }
         protected override System.Threading.Tasks.Task InitializeAsync(object? initializationData = null) { }
     }
     public class TokenRequest : Duende.IdentityModel.Client.ProtocolRequest


### PR DESCRIPTION
@0xced wrote

> As described by [RFC 7662 - OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)

[This PR](https://github.com/IdentityModel/IdentityModel/pull/577) has been ported to this repository.