### PR TITLE
Build - Add capability to release from target branch

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -109,7 +109,8 @@ void GenerateReleaseWorkflow(Component component)
 
     workflow.On
         .WorkflowDispatch()
-        .Inputs(new StringInput("version", "Version in format X.Y.Z or X.Y.Z-preview.", true, "0.0.0"));
+        .Inputs(new StringInput("version", "Version in format X.Y.Z or X.Y.Z-preview.", true, "0.0.0"))
+        .Inputs(new StringInput("target-branch", "(Optional) the name of the branch to release from", false, "main"));
 
     workflow.EnvDefaults();
 
@@ -122,6 +123,11 @@ void GenerateReleaseWorkflow(Component component)
 
     tagJob.Step()
         .ActionsCheckout();
+
+    tagJob.Step()
+        .Name("Checkout target branch")
+        .If("github.event.inputs.branch != 'main'")
+        .Run("git checkout ${{ github.event.inputs.branch }}");
 
     tagJob.StepSetupDotNet();
 

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -4,11 +4,11 @@ name: access-token-management/release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+      target-branch:
+        description: '(Optional) the name of the branch to release from'
         type: string
-        required: true
-        default: '0.0.0'
+        required: false
+        default: 'main'
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -28,6 +28,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Checkout target branch
+      if: github.event.inputs.branch != 'main'
+      run: git checkout ${{ github.event.inputs.branch }}
     - name: Setup Dotnet
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -4,11 +4,11 @@ name: identity-model-oidc-client/release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+      target-branch:
+        description: '(Optional) the name of the branch to release from'
         type: string
-        required: true
-        default: '0.0.0'
+        required: false
+        default: 'main'
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -28,6 +28,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Checkout target branch
+      if: github.event.inputs.branch != 'main'
+      run: git checkout ${{ github.event.inputs.branch }}
     - name: Setup Dotnet
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -4,11 +4,11 @@ name: identity-model/release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+      target-branch:
+        description: '(Optional) the name of the branch to release from'
         type: string
-        required: true
-        default: '0.0.0'
+        required: false
+        default: 'main'
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -28,6 +28,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Checkout target branch
+      if: github.event.inputs.branch != 'main'
+      run: git checkout ${{ github.event.inputs.branch }}
     - name: Setup Dotnet
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -4,11 +4,11 @@ name: ignore-this/release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+      target-branch:
+        description: '(Optional) the name of the branch to release from'
         type: string
-        required: true
-        default: '0.0.0'
+        required: false
+        default: 'main'
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -28,6 +28,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Checkout target branch
+      if: github.event.inputs.branch != 'main'
+      run: git checkout ${{ github.event.inputs.branch }}
     - name: Setup Dotnet
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
       with:


### PR DESCRIPTION
**What issue does this PR address?**
Release builds can now also release from a target (IE a release) branch. 

