### PR TITLE
fix issue with workflow gen program that version input was missing

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -109,8 +109,9 @@ void GenerateReleaseWorkflow(Component component)
 
     workflow.On
         .WorkflowDispatch()
-        .Inputs(new StringInput("version", "Version in format X.Y.Z or X.Y.Z-preview.", true, "0.0.0"))
-        .Inputs(new StringInput("target-branch", "(Optional) the name of the branch to release from", false, "main"));
+        .Inputs(
+            new StringInput("version", "Version in format X.Y.Z or X.Y.Z-preview.", true, "0.0.0")
+            , new StringInput("target-branch", "(Optional) the name of the branch to release from", false, "main"));
 
     workflow.EnvDefaults();
 

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -4,6 +4,11 @@ name: access-token-management/release
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        type: string
+        required: true
+        default: '0.0.0'
       target-branch:
         description: '(Optional) the name of the branch to release from'
         type: string

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -4,6 +4,11 @@ name: identity-model-oidc-client/release
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        type: string
+        required: true
+        default: '0.0.0'
       target-branch:
         description: '(Optional) the name of the branch to release from'
         type: string

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -4,6 +4,11 @@ name: identity-model/release
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        type: string
+        required: true
+        default: '0.0.0'
       target-branch:
         description: '(Optional) the name of the branch to release from'
         type: string

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -4,6 +4,11 @@ name: ignore-this/release
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        type: string
+        required: true
+        default: '0.0.0'
       target-branch:
         description: '(Optional) the name of the branch to release from'
         type: string


### PR DESCRIPTION
**What issue does this PR address?**

The method .Input() can't be called multiple times. The solution was to call it with multiple parameters. 


