### PR TITLE
Allow a custom IDistributedCache to be resolved

### DIFF
--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementDefaults.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementDefaults.cs
@@ -17,4 +17,11 @@ public static class ClientCredentialsTokenManagementDefaults
     /// Name used to propagate access token parameters to HttpRequestMessage
     /// </summary>
     public const string TokenRequestParametersOptionsName = "Duende.AccessTokenManagement.AccessTokenParameters";
+
+}
+
+public static class ServiceProviderKeys
+{
+    public const string DistributedClientCredentialsTokenCache = "DistributedClientCredentialsTokenCache";
+    public const string DistributedDPoPNonceStore = "DistributedDPoPNonceStore";
 }

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using Microsoft.Extensions.Logging;
-
 namespace Duende.AccessTokenManagement;
 
 /// <summary>
@@ -10,8 +8,7 @@ namespace Duende.AccessTokenManagement;
 /// </summary>
 public class ClientCredentialsTokenManagementService(
     IClientCredentialsTokenEndpointService clientCredentialsTokenEndpointService,
-    IClientCredentialsTokenCache tokenCache,
-    ILogger<ClientCredentialsTokenManagementService> logger
+    IClientCredentialsTokenCache tokenCache
 ) : IClientCredentialsTokenManagementService
 {
 
@@ -22,27 +19,6 @@ public class ClientCredentialsTokenManagementService(
         CancellationToken cancellationToken = default)
     {
         parameters ??= new TokenRequestParameters();
-
-        if (parameters.ForceRenewal == false)
-        {
-            try
-            {
-                var item = await tokenCache.GetAsync(
-                    clientName: clientName,
-                    requestParameters: parameters,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-                if (item != null)
-                {
-                    return item;
-                }
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e,
-                    "Error trying to obtain token from cache for client {clientName}. Error = {error}. Will obtain new token.",
-                    clientName, e.Message);
-            }
-        }
 
         return await tokenCache.GetOrCreateAsync(
             clientName: clientName,
@@ -57,12 +33,12 @@ public class ClientCredentialsTokenManagementService(
     }
 
     /// <inheritdoc/>
-    public Task DeleteAccessTokenAsync(
+    public async Task DeleteAccessTokenAsync(
         string clientName,
         TokenRequestParameters? parameters = null,
         CancellationToken cancellationToken = default)
     {
         parameters ??= new TokenRequestParameters();
-        return tokenCache.DeleteAsync(clientName, parameters, cancellationToken);
+        await tokenCache.DeleteAsync(clientName, parameters, cancellationToken);
     }
 }

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.AccessTokenManagement;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
@@ -38,12 +39,23 @@ public static class ClientCredentialsTokenManagementServiceCollectionExtensions
         services.TryAddSingleton<ITokenRequestSynchronization, TokenRequestSynchronization>();
 
         services.TryAddTransient<IClientCredentialsTokenManagementService, ClientCredentialsTokenManagementService>();
+
+        services.TryAddSingleton(TimeProvider.System);
+
+        // By default, resolve the distributed cache for the DistributedClientCredentialsTokenCache
+        // without key. If desired, a consumers can register the distributed cache with a key
+        services.TryAddKeyedTransient<IDistributedCache>(ServiceProviderKeys.DistributedClientCredentialsTokenCache, (sp, _) => sp.GetRequiredService<IDistributedCache>());
         services.TryAddTransient<IClientCredentialsTokenCache, DistributedClientCredentialsTokenCache>();
         services.TryAddTransient<IClientCredentialsTokenEndpointService, ClientCredentialsTokenEndpointService>();
         services.TryAddTransient<IClientAssertionService, DefaultClientAssertionService>();
 
         services.TryAddTransient<IDPoPProofService, DefaultDPoPProofService>();
         services.TryAddTransient<IDPoPKeyStore, DefaultDPoPKeyStore>();
+
+        // ** DistributedDPoPNonceStore **
+        // By default, resolve the distributed cache for the DistributedClientCredentialsTokenCache
+        // without key. If desired, a consumers can register the distributed cache with a key
+        services.TryAddKeyedTransient<IDistributedCache>(ServiceProviderKeys.DistributedDPoPNonceStore, (sp, _) => sp.GetRequiredService<IDistributedCache>());
         services.TryAddTransient<IDPoPNonceStore, DistributedDPoPNonceStore>();
 
         services.AddHttpClient(ClientCredentialsTokenManagementDefaults.BackChannelHttpClientName);

--- a/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
+++ b/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.AccessTokenManagement;
@@ -23,7 +24,7 @@ public class DistributedDPoPNonceStore : IDPoPNonceStore
     /// <param name="cache"></param>
     /// <param name="logger"></param>
     public DistributedDPoPNonceStore(
-        IDistributedCache cache,
+        [FromKeyedServices(ServiceProviderKeys.DistributedDPoPNonceStore)] IDistributedCache cache,
         ILogger<DistributedDPoPNonceStore> logger)
     {
         _cache = cache;

--- a/access-token-management/test/AccessTokenManagement.Tests/TaskTimeoutExtensions.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/TaskTimeoutExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Duende.AccessTokenManagement.Tests;
+
+public static class TaskTimeoutExtensions
+{
+    private static TimeSpan IncreaseTimeoutIfDebuggerAttached(TimeSpan timeout)
+    {
+        // Wait a bit longer if the debugger is attached. This prevents timeouts during debugging.
+        if (Debugger.IsAttached) return TimeSpan.FromMinutes(10);
+
+        return timeout == default ? TimeSpan.FromSeconds(2) : timeout;
+    }
+
+    public static async Task ThrowOnTimeout(this Task task, TimeSpan timeout = default)
+    {
+        timeout = IncreaseTimeoutIfDebuggerAttached(timeout);
+
+        using (var cts = new CancellationTokenSource())
+        {
+            var delayTask = Task.Delay(timeout, cts.Token);
+
+            var resultTask = await Task.WhenAny(task, delayTask);
+            if (resultTask == delayTask)
+                // Operation cancelled
+                throw new OperationCanceledException();
+            cts.Cancel();
+
+            await task;
+        }
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**

You're now able to inject a custom instance of IDistributedCache. This is done using keyed dependencies.

A keyed dependency is added for each consumer. So per consumer you can choose to override it with a specific cache. 

``` csharp
services.AddKeyedSingleton<IDistributedCache>(nameof(DistributedClientCredentialsTokenCache), replacementCache);

// and / or

services.AddKeyedSingleton<IDistributedCache>(nameof(DistributedDPoPNonceStore), replacementCache);

```

Fixes: https://github.com/DuendeSoftware/foss/issues/50