### PR TITLE
remove .Wait() from unit tests

### DIFF
--- a/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandlerTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandlerTests.cs
@@ -12,9 +12,9 @@ public class AccessTokenHandlerTests
 
     AccessTokenHandlerSubject _subject;
 
-    public AccessTokenHandlerTests()
+    public AccessTokenHandlerTests(ITestOutputHelper output)
     {
-        _subject = new AccessTokenHandlerSubject(_testDPoPProofService, new TestDPoPNonceStore(), new TestLoggerProvider().CreateLogger("AccessTokenHandlerSubject"));
+        _subject = new AccessTokenHandlerSubject(_testDPoPProofService, new TestDPoPNonceStore(), new TestLoggerProvider(output.WriteLine, "AccessTokenHandler").CreateLogger("AccessTokenHandlerSubject"));
         _subject.InnerHandler = _testHttpMessageHandler;
     }
 

--- a/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementApiTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementApiTests.cs
@@ -11,21 +11,21 @@ using System.Text.Json;
 
 namespace Duende.AccessTokenManagement.Tests;
 
-public class ClientTokenManagementApiTests : IntegrationTestBase
+public class ClientTokenManagementApiTests(ITestOutputHelper output) : IntegrationTestBase(output), IAsyncLifetime
 {
-    private static readonly string _jwkJson;
+    private static readonly string _jwkJson = CreateJWKJson();
 
-    private HttpClient _client;
-    private IClientCredentialsTokenManagementService _tokenService;
-    private IHttpClientFactory _clientFactory;
-    private ClientCredentialsClient _clientOptions;
+    private IClientCredentialsTokenManagementService _tokenService = null!;
+    private IHttpClientFactory _clientFactory = null!;
+    private ClientCredentialsClient _clientOptions = null!;
 
-    static ClientTokenManagementApiTests()
+    private static string CreateJWKJson()
     {
         var key = CryptoHelper.CreateRsaSecurityKey();
         var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
         jwk.Alg = "RS256";
-        _jwkJson = JsonSerializer.Serialize(jwk);
+        var jwkJson = JsonSerializer.Serialize(jwk);
+        return jwkJson;
     }
 
     public override async ValueTask InitializeAsync()
@@ -51,7 +51,6 @@ public class ClientTokenManagementApiTests : IntegrationTestBase
             });
 
         var provider = services.BuildServiceProvider();
-        _client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
         _tokenService = provider.GetRequiredService<IClientCredentialsTokenManagementService>();
         _clientFactory = provider.GetRequiredService<IHttpClientFactory>();
         _clientOptions = provider.GetRequiredService<IOptionsMonitor<ClientCredentialsClient>>().Get("test");

--- a/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementApiTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementApiTests.cs
@@ -28,8 +28,9 @@ public class ClientTokenManagementApiTests : IntegrationTestBase
         _jwkJson = JsonSerializer.Serialize(jwk);
     }
 
-    public ClientTokenManagementApiTests()
+    public override async ValueTask InitializeAsync()
     {
+        await base.InitializeAsync();
         var services = new ServiceCollection();
 
         services.AddDistributedMemoryCache();
@@ -55,6 +56,7 @@ public class ClientTokenManagementApiTests : IntegrationTestBase
         _clientFactory = provider.GetRequiredService<IHttpClientFactory>();
         _clientOptions = provider.GetRequiredService<IOptionsMonitor<ClientCredentialsClient>>().Get("test");
     }
+
     public class ApiHandler : DelegatingHandler
     {
         private HttpMessageHandler? _innerHandler;

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/ApiHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/ApiHost.cs
@@ -15,8 +15,13 @@ public class ApiHost : GenericHost
     private readonly IdentityServerHost _identityServerHost;
     public event Action<Microsoft.AspNetCore.Http.HttpContext> ApiInvoked = ctx => { };
         
-    public ApiHost(IdentityServerHost identityServerHost, string scope, string baseAddress = "https://api", string resource = "urn:api") 
-        : base(baseAddress)
+    public ApiHost(
+        WriteTestOutput writeTestOutput, 
+        IdentityServerHost identityServerHost, 
+        string scope, 
+        string baseAddress = "https://api", 
+        string resource = "urn:api") 
+        : base(writeTestOutput, baseAddress)
     {
         _identityServerHost = identityServerHost;
         _identityServerHost.ApiScopes.Add(new ApiScope(scope));

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
@@ -23,12 +23,13 @@ public class AppHost : GenericHost
     private readonly Action<UserTokenManagementOptions>? _configureUserTokenManagementOptions;
 
     public AppHost(
+        WriteTestOutput writeTestOutput,
         IdentityServerHost identityServerHost, 
         ApiHost apiHost, 
         string clientId,
         string baseAddress = "https://app",
         Action<UserTokenManagementOptions>? configureUserTokenManagementOptions = default)
-        : base(baseAddress)
+        : base(writeTestOutput, baseAddress)
     {
         _identityServerHost = identityServerHost;
         _apiHost = apiHost;

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/GenericHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/GenericHost.cs
@@ -14,7 +14,7 @@ using System.Security.Claims;
 
 namespace Duende.AccessTokenManagement.Tests;
 
-public class GenericHost
+public class GenericHost : IAsyncDisposable
 {
     public GenericHost(string baseAddress = "https://server")
     {
@@ -177,5 +177,24 @@ public class GenericHost
     public Task IssueSessionCookieAsync(string sub, params Claim[] claims)
     {
         return IssueSessionCookieAsync(claims.Append(new Claim("sub", sub)).ToArray());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await CastAndDispose(Server);
+        await CastAndDispose(BrowserClient);
+        await CastAndDispose(HttpClient);
+        await CastAndDispose(HttpMessageHandler);
+        await CastAndDispose(Logger);
+
+        return;
+
+        static async ValueTask CastAndDispose(IDisposable resource)
+        {
+            if (resource is IAsyncDisposable resourceAsyncDisposable)
+                await resourceAsyncDisposable.DisposeAsync();
+            else
+                resource?.Dispose();
+        }
     }
 }

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/IdentityServerHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/IdentityServerHost.cs
@@ -15,8 +15,8 @@ namespace Duende.AccessTokenManagement.Tests;
 
 public class IdentityServerHost : GenericHost
 {
-    public IdentityServerHost(string baseAddress = "https://identityserver") 
-        : base(baseAddress)
+    public IdentityServerHost(WriteTestOutput writeTestOutput, string baseAddress = "https://identityserver") 
+        : base(writeTestOutput, baseAddress)
     {
         OnConfigureServices += ConfigureServices;
         OnConfigure += Configure;
@@ -108,7 +108,7 @@ public class IdentityServerHost : GenericHost
     {
         var descriptor = new SecurityTokenDescriptor
         {
-            Issuer = _baseAddress,
+            Issuer = BaseAddress,
             Audience = clientId,
             Claims = new Dictionary<string, object>
             {

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/IntegrationTestBase.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/IntegrationTestBase.cs
@@ -8,15 +8,15 @@ using System.Security.Claims;
 
 namespace Duende.AccessTokenManagement.Tests;
 
-public class IntegrationTestBase : IAsyncLifetime
+public class IntegrationTestBase : IAsyncDisposable
 {
     protected readonly IdentityServerHost IdentityServerHost;
     protected ApiHost ApiHost;
     protected AppHost AppHost;
 
-    public IntegrationTestBase(string clientId = "web", Action<UserTokenManagementOptions>? configureUserTokenManagementOptions = null)
+    public IntegrationTestBase(ITestOutputHelper output, string clientId = "web", Action<UserTokenManagementOptions>? configureUserTokenManagementOptions = null)
     {
-        IdentityServerHost = new IdentityServerHost();
+        IdentityServerHost = new IdentityServerHost(output.WriteLine);
 
         IdentityServerHost.Clients.Add(new Client
         {
@@ -67,9 +67,9 @@ public class IntegrationTestBase : IAsyncLifetime
             AccessTokenLifetime = 10
         });
 
-        ApiHost = new ApiHost(IdentityServerHost, "scope1");
+        ApiHost = new ApiHost(output.WriteLine, IdentityServerHost, "scope1");
 
-        AppHost = new AppHost(IdentityServerHost, ApiHost, clientId, configureUserTokenManagementOptions: configureUserTokenManagementOptions);
+        AppHost = new AppHost(output.WriteLine, IdentityServerHost, ApiHost, clientId, configureUserTokenManagementOptions: configureUserTokenManagementOptions);
     }
 
     public async Task Login(string sub)

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/IntegrationTestBase.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/IntegrationTestBase.cs
@@ -8,7 +8,7 @@ using System.Security.Claims;
 
 namespace Duende.AccessTokenManagement.Tests;
 
-public class IntegrationTestBase
+public class IntegrationTestBase : IAsyncLifetime
 {
     protected readonly IdentityServerHost IdentityServerHost;
     protected ApiHost ApiHost;
@@ -67,17 +67,27 @@ public class IntegrationTestBase
             AccessTokenLifetime = 10
         });
 
-        IdentityServerHost.InitializeAsync().Wait();
-
         ApiHost = new ApiHost(IdentityServerHost, "scope1");
-        ApiHost.InitializeAsync().Wait();
 
         AppHost = new AppHost(IdentityServerHost, ApiHost, clientId, configureUserTokenManagementOptions: configureUserTokenManagementOptions);
-        AppHost.InitializeAsync().Wait();
     }
 
     public async Task Login(string sub)
     {
         await IdentityServerHost.IssueSessionCookieAsync(new Claim("sub", sub));
+    }
+
+    public virtual async ValueTask DisposeAsync()
+    {
+        await IdentityServerHost.DisposeAsync();
+        await ApiHost.DisposeAsync();
+        await AppHost.DisposeAsync();
+    }
+
+    public virtual async ValueTask InitializeAsync()
+    {
+        await ApiHost.InitializeAsync();
+        await AppHost.InitializeAsync();
+        await IdentityServerHost.InitializeAsync();
     }
 }

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/TestLoggerProvider.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/TestLoggerProvider.cs
@@ -50,7 +50,12 @@ public class TestLoggerProvider(WriteTestOutput writeOutput, string name) : ILog
     {
         try
         {
-            _writeOutput?.Invoke(_watch.Elapsed.TotalMilliseconds.ToString("0000") + "ms - " + _name + msg);
+            var message = _watch.Elapsed.TotalMilliseconds.ToString("0000") + "ms - " + _name + msg;
+#if NCRUNCH
+            Console.WriteLine(message);
+#else
+            _writeOutput?.Invoke(message);
+#endif
         }
         catch (Exception)
         {

--- a/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementTests.cs
@@ -10,14 +10,12 @@ using RichardSzalay.MockHttp;
 
 namespace Duende.AccessTokenManagement.Tests;
 
-public class UserTokenManagementTests : IntegrationTestBase
+public class UserTokenManagementTests(ITestOutputHelper output) : IntegrationTestBase(output, "web")
 {
-    public UserTokenManagementTests() : base("web")
-    { }
-
     [Fact]
     public async Task Anonymous_user_should_return_user_token_error()
     {
+        await InitializeAsync();
         var response = await AppHost.BrowserClient!.GetAsync(AppHost.Url("/user_token"));
         var token = await response.Content.ReadFromJsonAsync<UserToken>();
 
@@ -27,6 +25,7 @@ public class UserTokenManagementTests : IntegrationTestBase
     [Fact]
     public async Task Anonymous_user_should_return_client_token()
     {
+        await InitializeAsync();
         var response = await AppHost.BrowserClient!.GetAsync(AppHost.Url("/client_token"));
         var token = await response.Content.ReadFromJsonAsync<ClientCredentialsToken>();
 
@@ -57,7 +56,7 @@ public class UserTokenManagementTests : IntegrationTestBase
             .WithFormData("grant_type", "authorization_code")
             .Respond("application/json", JsonSerializer.Serialize(initialTokenResponse));
 
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         // 1st request
@@ -102,7 +101,7 @@ public class UserTokenManagementTests : IntegrationTestBase
             .WithFormData("grant_type", "authorization_code")
             .Respond("application/json", JsonSerializer.Serialize(initialTokenResponse));
 
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         var response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"));
@@ -135,7 +134,7 @@ public class UserTokenManagementTests : IntegrationTestBase
             .WithFormData("grant_type", "authorization_code")
             .Respond("application/json", JsonSerializer.Serialize(initialTokenResponse));
 
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         var response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"));
@@ -168,7 +167,7 @@ public class UserTokenManagementTests : IntegrationTestBase
             .WithFormData("grant_type", "authorization_code")
             .Respond("application/json", JsonSerializer.Serialize(initialTokenResponse));
 
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         var response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"));
@@ -236,7 +235,7 @@ public class UserTokenManagementTests : IntegrationTestBase
             .Respond("application/json", JsonSerializer.Serialize(refreshTokenResponse2));
 
         // setup host
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         // first request should trigger refresh
@@ -319,7 +318,7 @@ public class UserTokenManagementTests : IntegrationTestBase
             .Respond("application/json", JsonSerializer.Serialize(resource2TokenResponse));
 
         // setup host
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         // first request - no resource
@@ -389,7 +388,7 @@ public class UserTokenManagementTests : IntegrationTestBase
             .Respond("application/json", JsonSerializer.Serialize(refreshTokenResponse));
 
         // setup host
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         // first request should trigger refresh
@@ -406,7 +405,7 @@ public class UserTokenManagementTests : IntegrationTestBase
     {
         // setup host
         AppHost.ClientId = "web.short";
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
         var firstResponse = await AppHost.BrowserClient.GetAsync(AppHost.Url("/call_api"));
         var firstToken = await firstResponse.Content.ReadFromJsonAsync<TokenEchoResponse>();
@@ -428,7 +427,7 @@ public class UserTokenManagementTests : IntegrationTestBase
     [Fact]
     public async Task Logout_should_revoke_refresh_tokens()
     {
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         var response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"));

--- a/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementWithDPoPTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementWithDPoPTests.cs
@@ -11,27 +11,26 @@ using RichardSzalay.MockHttp;
 
 namespace Duende.AccessTokenManagement.Tests;
 
-public class UserTokenManagementWithDPoPTests : IntegrationTestBase
+public class UserTokenManagementWithDPoPTests(ITestOutputHelper output)
+    : IntegrationTestBase(output, "dpop", opt =>
+    {
+        opt.DPoPJsonWebKey = _privateJWK;
+    })
 {
     // (An example jwk from RFC7517)
     const string _privateJWK = "{\"kty\":\"RSA\",\"n\":\"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw\",\"e\":\"AQAB\",\"d\":\"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q\",\"p\":\"83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs\",\"q\":\"3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk\",\"dp\":\"G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0\",\"dq\":\"s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk\",\"qi\":\"GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU\",\"alg\":\"RS256\",\"kid\":\"2011-04-29\"}";
 
-    public UserTokenManagementWithDPoPTests() : base("dpop", opt =>
-    {
-        opt.DPoPJsonWebKey = _privateJWK;
-    }){}
-
     [Fact]
     public async Task dpop_jtk_is_attached_to_authorize_requests()
     {
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice", verifyDpopThumbprintSent: true);
     }
 
     [Fact]
     public async Task dpop_token_refresh_should_succeed()
     {
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         // The DPoP proof token is valid for 1 second, and that validity is checked with the server nonce.
@@ -104,7 +103,7 @@ public class UserTokenManagementWithDPoPTests : IntegrationTestBase
             .Respond("application/json", JsonSerializer.Serialize(tokenResponse));
 
 
-        await AppHost.InitializeAsync();
+        await InitializeAsync();
         await AppHost.LoginAsync("alice");
 
         // This API call triggers a refresh

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/GenericHost.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/GenericHost.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Duende.IdentityModel.OidcClient.DPoP.Framework;
 
-public class GenericHost
+public class GenericHost : IAsyncDisposable
 {
     public GenericHost(string baseAddress = "https://server")
     {
@@ -99,5 +99,22 @@ public class GenericHost
         _appServices = app.ApplicationServices;
             
         OnConfigure(app);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Server != null) await CastAndDispose(Server);
+        if (HttpClient != null) await CastAndDispose(HttpClient);
+        if (Logger != null) await CastAndDispose(Logger);
+
+        return;
+
+        static async ValueTask CastAndDispose(IDisposable resource)
+        {
+            if (resource is IAsyncDisposable resourceAsyncDisposable)
+                await resourceAsyncDisposable.DisposeAsync();
+            else
+                resource?.Dispose();
+        }
     }
 }

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/IntegrationTestBase.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/IntegrationTestBase.cs
@@ -3,7 +3,7 @@
 
 namespace Duende.IdentityModel.OidcClient.DPoP.Framework;
 
-public class IntegrationTestBase
+public class IntegrationTestBase : IAsyncLifetime
 {
     protected readonly IdentityServerHost IdentityServerHost;
     protected ApiHost ApiHost;
@@ -11,9 +11,18 @@ public class IntegrationTestBase
     public IntegrationTestBase()
     {
         IdentityServerHost = new IdentityServerHost();
-        IdentityServerHost.InitializeAsync().Wait();
-
         ApiHost = new ApiHost(IdentityServerHost);
-        ApiHost.InitializeAsync().Wait();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await ApiHost.DisposeAsync();
+        await IdentityServerHost.DisposeAsync();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await ApiHost.InitializeAsync();
+        await IdentityServerHost.InitializeAsync();
     }
 }


### PR DESCRIPTION
**What issue does this PR address?**
.Wait() is now removed from the unit tests. 

