### PR TITLE
include the ID token in the refresh token result

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/UserToken.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/UserToken.cs
@@ -12,4 +12,11 @@ public class UserToken : ClientCredentialsToken
     /// The refresh token
     /// </summary>
     public string? RefreshToken { get; set; }
+
+    /// <summary>
+    /// The identity token that may be populated by the OP when refreshing the access token. This
+    /// value is not stored, but available should some OP's require to send this value, for example
+    /// during logout. 
+    /// </summary>
+    public string? IdentityToken { get; set; }
 }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/UserTokenEndpointService.cs
@@ -135,6 +135,7 @@ public class UserTokenEndpointService : IUserTokenEndpointService
         }
         else
         {
+            token.IdentityToken = response.IdentityToken;
             token.AccessToken = response.AccessToken;
             token.AccessTokenType = response.TokenType;
             token.DPoPJsonWebKey = dPoPJsonWebKey;

--- a/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementTests.cs
@@ -212,6 +212,7 @@ public class UserTokenManagementTests : IntegrationTestBase
         // Respond to refresh with a short token lifetime so that we trigger another refresh on 2nd use
         var refreshTokenResponse = new
         {
+            id_token = "refreshed1_id_token",
             access_token = "refreshed1_access_token",
             token_type = "token_type1",
             expires_in = 10,
@@ -225,6 +226,7 @@ public class UserTokenManagementTests : IntegrationTestBase
         // Respond to second refresh with a long token lifetime so that we don't trigger another refresh on 3rd use
         var refreshTokenResponse2 = new
         {
+            id_token = "refreshed2_id_token",
             access_token = "refreshed2_access_token",
             token_type = "token_type2",
             expires_in = 3600,
@@ -245,6 +247,7 @@ public class UserTokenManagementTests : IntegrationTestBase
 
         token.ShouldNotBeNull();
         token.IsError.ShouldBeFalse();
+        token.IdentityToken.ShouldBe("refreshed1_id_token");
         token.AccessToken.ShouldBe("refreshed1_access_token");
         token.AccessTokenType.ShouldBe("token_type1");
         token.RefreshToken.ShouldBe("refreshed1_refresh_token");
@@ -256,6 +259,7 @@ public class UserTokenManagementTests : IntegrationTestBase
 
         token.ShouldNotBeNull();
         token.IsError.ShouldBeFalse();
+        token.IdentityToken.ShouldBe("refreshed2_id_token");
         token.AccessToken.ShouldBe("refreshed2_access_token");
         token.AccessTokenType.ShouldBe("token_type2");
         token.RefreshToken.ShouldBe("refreshed2_refresh_token");


### PR DESCRIPTION
**What issue does this PR address?**

The Identity Token is now part of the UserToken if the OP returns the Identity Token on a Refresh Token Result. 

https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse

fixes: https://github.com/DuendeSoftware/foss/issues/53