### PR TITLE
Add HybridCache to ATM

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,14 +17,14 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <FrameworkVersion>8.0.1</FrameworkVersion>
-    <ExtensionsVersion>8.0.0</ExtensionsVersion>
+    <ExtensionsVersion>9.0.3</ExtensionsVersion>
     <WilsonVersion>[8.0.1,9.0.0)</WilsonVersion> 
     <IdentityServerVersion>7.0.8</IdentityServerVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0'">
     <FrameworkVersion>9.0.0</FrameworkVersion>
-    <ExtensionsVersion>9.0.0</ExtensionsVersion>
+    <ExtensionsVersion>9.0.3</ExtensionsVersion>
     <WilsonVersion>[8.0.1,9.0.0)</WilsonVersion>
     <IdentityServerVersion>7.0.8</IdentityServerVersion>
   </PropertyGroup>
@@ -40,7 +40,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid " Version="9.3.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(ExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />

--- a/access-token-management/samples/WorkerDI/Program.cs
+++ b/access-token-management/samples/WorkerDI/Program.cs
@@ -31,8 +31,6 @@ public class Program
                 
             .ConfigureServices((services) =>
             {
-                services.AddDistributedMemoryCache();
-
                 services.AddClientCredentialsTokenManagement();
                 services.AddSingleton(new DiscoveryCache("https://demo.duendesoftware.com"));
                 services.AddSingleton<IConfigureOptions<ClientCredentialsClient>, ClientCredentialsClientConfigureOptions>();

--- a/access-token-management/src/AccessTokenManagement/AccessTokenManagement.csproj
+++ b/access-token-management/src/AccessTokenManagement/AccessTokenManagement.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Duende.IdentityModel" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
@@ -11,8 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// </summary>
 public class ClientCredentialsTokenManagementService(
     IClientCredentialsTokenEndpointService clientCredentialsTokenEndpointService,
-    IClientCredentialsTokenCache tokenCache,
-    ILogger<ClientCredentialsTokenManagementService> logger
+    IClientCredentialsTokenCache tokenCache
 ) : IClientCredentialsTokenManagementService
 {
 
@@ -23,27 +22,6 @@ public class ClientCredentialsTokenManagementService(
         CancellationToken cancellationToken = default)
     {
         parameters ??= new TokenRequestParameters();
-
-        if (parameters.ForceRenewal == false)
-        {
-            try
-            {
-                var item = await tokenCache.GetAsync(
-                    clientName: clientName, 
-                    requestParameters: parameters, 
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-                if (item != null)
-                {
-                    return item;
-                }
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e,
-                    "Error trying to obtain token from cache for client {clientName}. Error = {error}. Will obtain new token.", 
-                    clientName, e.Message);
-            }
-        }
 
         return await tokenCache.GetOrCreateAsync(
             clientName: clientName, 
@@ -58,12 +36,12 @@ public class ClientCredentialsTokenManagementService(
     }
 
     /// <inheritdoc/>
-    public Task DeleteAccessTokenAsync(
+    public async Task DeleteAccessTokenAsync(
         string clientName,
         TokenRequestParameters? parameters = null,
         CancellationToken cancellationToken = default)
     {
         parameters ??= new TokenRequestParameters();
-        return tokenCache.DeleteAsync(clientName, parameters, cancellationToken);
+        await tokenCache.DeleteAsync(clientName, parameters, cancellationToken);
     }
 }

--- a/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
+++ b/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Duende.AccessTokenManagement;
 
@@ -17,6 +18,11 @@ public class DistributedDPoPNonceStore : IDPoPNonceStore
 
     private readonly HybridCache _cache;
     private readonly ILogger<DistributedDPoPNonceStore> _logger;
+
+    private static readonly HybridCacheEntryOptions NonceStoreCacheOptions = new HybridCacheEntryOptions()
+    {
+        LocalCacheExpiration = TimeSpan.FromHours(1)
+    };
 
     /// <summary>
     /// ctor
@@ -56,16 +62,11 @@ public class DistributedDPoPNonceStore : IDPoPNonceStore
 
         var data = nonce;
 
-        var cacheExpiration = TimeSpan.FromHours(1);
-        var entryOptions = new HybridCacheEntryOptions()
-        {
-            Expiration = cacheExpiration
-        };
 
-        _logger.LogTrace("Caching DPoP nonce for URL: {url}, method: {method}. Expiration: {expiration}", context.Url, context.Method, cacheExpiration);
+        _logger.LogTrace("Caching DPoP nonce for URL: {url}, method: {method}. Expiration: {expiration}", context.Url, context.Method, NonceStoreCacheOptions.Expiration);
 
         var cacheKey = GenerateCacheKey(context);
-        await _cache.SetAsync(cacheKey, data, entryOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await _cache.SetAsync(cacheKey, data, NonceStoreCacheOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
 

--- a/access-token-management/src/AccessTokenManagement/HybridCacheExtMethods.cs
+++ b/access-token-management/src/AccessTokenManagement/HybridCacheExtMethods.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Caching.Hybrid;
+
+namespace Duende.AccessTokenManagement;
+
+/// <summary>
+/// This extension method is created because we don't yet have a 'GetOrDefault' method
+/// on HybridCache. This is under consideration:
+///
+/// https://github.com/dotnet/extensions/issues/5688#issuecomment-2692247434
+/// </summary>
+public static class HybridCacheExtMethods
+{
+    private static readonly HybridCacheEntryOptions GetOnlyEntryOptions = new()
+    {
+        Flags = HybridCacheEntryFlags.DisableLocalCacheWrite 
+                | HybridCacheEntryFlags.DisableDistributedCacheWrite 
+                | HybridCacheEntryFlags.DisableUnderlyingData
+    };
+
+    public static async ValueTask<T?> GetOrDefaultAsync<T>(this HybridCache cache, string key)
+    {
+        return await cache.GetOrCreateAsync<T?>(
+            key,
+            null!, // Don't return a value if it's not in the cache. Also, don't write it to the cache
+            GetOnlyEntryOptions
+        );
+    }
+}

--- a/access-token-management/src/AccessTokenManagement/HybridCacheExtMethods.cs
+++ b/access-token-management/src/AccessTokenManagement/HybridCacheExtMethods.cs
@@ -17,12 +17,11 @@ public static class HybridCacheExtMethods
                 | HybridCacheEntryFlags.DisableUnderlyingData
     };
 
-    public static async ValueTask<T?> GetOrDefaultAsync<T>(this HybridCache cache, string key)
+    public static async ValueTask<T?> GetOrDefaultAsync<T>(this HybridCache cache, string key, CancellationToken cancellationToken = default)
     {
         return await cache.GetOrCreateAsync<T?>(
             key,
             null!, // Don't return a value if it's not in the cache. Also, don't write it to the cache
-            GetOnlyEntryOptions
-        );
+            GetOnlyEntryOptions, cancellationToken: cancellationToken);
     }
 }

--- a/access-token-management/src/AccessTokenManagement/Interfaces/IClientCredentialsTokenCache.cs
+++ b/access-token-management/src/AccessTokenManagement/Interfaces/IClientCredentialsTokenCache.cs
@@ -29,26 +29,13 @@ public interface IClientCredentialsTokenCache
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves a client access token from the cache
-    /// </summary>
-    /// <param name="clientName"></param>
-    /// <param name="requestParameters"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    Task<ClientCredentialsToken?> GetAsync(
-        string clientName,
-        TokenRequestParameters requestParameters,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Deletes a client access token from the cache
     /// </summary>
     /// <param name="clientName"></param>
     /// <param name="requestParameters"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task DeleteAsync(
-        string clientName,
+    ValueTask DeleteAsync(string clientName,
         TokenRequestParameters requestParameters,
         CancellationToken cancellationToken = default);
 }

--- a/access-token-management/test/AccessTokenManagement.Tests/BackChannelClientTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/BackChannelClientTests.cs
@@ -5,49 +5,9 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using Duende.IdentityModel.Client;
-using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using RichardSzalay.MockHttp;
 namespace Duende.AccessTokenManagement.Tests;
-
-public class HybridCacheTests
-{
-    [Fact]
-    public async Task Returning_null()
-    {
-        var services = new ServiceCollection()
-            .AddHybridCache()
-            .Services;
-
-        var cache = services.BuildServiceProvider()
-            .GetService<HybridCache>();
-
-        int count = 0;
-        object item;
-
-        try
-        {
-            item = await cache.GetOrCreateAsync<object>("key", (_) =>
-            {
-                count++;
-                throw new InvalidOperationException();
-                return ValueTask.FromResult<object>(null);
-            });
-        }
-        catch (InvalidOperationException)
-        {
-
-        }
-        item = await cache.GetOrCreateAsync<object>("key", (_) =>
-        {
-            count++;
-            return ValueTask.FromResult<object>(null);
-        });
-
-        item.ShouldBeNull();
-        count.ShouldBe(2);
-    }
-}
 
 public class BackChannelClientTests(ITestOutputHelper output)
 {

--- a/access-token-management/test/AccessTokenManagement.Tests/BackChannelClientTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/BackChannelClientTests.cs
@@ -5,10 +5,49 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using Duende.IdentityModel.Client;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using RichardSzalay.MockHttp;
-
 namespace Duende.AccessTokenManagement.Tests;
+
+public class HybridCacheTests
+{
+    [Fact]
+    public async Task Returning_null()
+    {
+        var services = new ServiceCollection()
+            .AddHybridCache()
+            .Services;
+
+        var cache = services.BuildServiceProvider()
+            .GetService<HybridCache>();
+
+        int count = 0;
+        object item;
+
+        try
+        {
+            item = await cache.GetOrCreateAsync<object>("key", (_) =>
+            {
+                count++;
+                throw new InvalidOperationException();
+                return ValueTask.FromResult<object>(null);
+            });
+        }
+        catch (InvalidOperationException)
+        {
+
+        }
+        item = await cache.GetOrCreateAsync<object>("key", (_) =>
+        {
+            count++;
+            return ValueTask.FromResult<object>(null);
+        });
+
+        item.ShouldBeNull();
+        count.ShouldBe(2);
+    }
+}
 
 public class BackChannelClientTests(ITestOutputHelper output)
 {
@@ -17,7 +56,6 @@ public class BackChannelClientTests(ITestOutputHelper output)
     {
         var services = new ServiceCollection();
 
-        services.AddDistributedMemoryCache();
         services.AddClientCredentialsTokenManagement()
             .AddClient("test", client =>
             {
@@ -48,7 +86,6 @@ public class BackChannelClientTests(ITestOutputHelper output)
     {
         var services = new ServiceCollection();
 
-        services.AddDistributedMemoryCache();
         services.AddClientCredentialsTokenManagement()
             .AddClient("test", client =>
             {
@@ -80,7 +117,6 @@ public class BackChannelClientTests(ITestOutputHelper output)
     {
         var services = new ServiceCollection();
 
-        services.AddDistributedMemoryCache();
         services.AddClientCredentialsTokenManagement()
             .AddClient("test", client =>
             {
@@ -130,7 +166,6 @@ public class BackChannelClientTests(ITestOutputHelper output)
     {
         var services = new ServiceCollection();
 
-        services.AddDistributedMemoryCache();
         services.AddClientCredentialsTokenManagement()
             .AddClient("test", client =>
             {
@@ -199,7 +234,6 @@ public class BackChannelClientTests(ITestOutputHelper output)
     {
         var services = new ServiceCollection();
 
-        services.AddDistributedMemoryCache();
         services.AddClientCredentialsTokenManagement()
             .AddClient("test", client =>
             {
@@ -278,7 +312,6 @@ public class BackChannelClientTests(ITestOutputHelper output)
 
         var services = new ServiceCollection();
 
-        services.AddDistributedMemoryCache();
         services.AddClientCredentialsTokenManagement()
             .AddClient("test", client =>
             {

--- a/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementTests.cs
@@ -113,7 +113,7 @@ public class ClientTokenManagementTests
         {
             access_token = "access_token",
             token_type = "token_type",
-            expires_in = 60,
+            expires_in = 100,
             scope = "scope"
         };
 
@@ -236,7 +236,7 @@ public class ClientTokenManagementTests
         {
             access_token = "access_token",
             token_type = "token_type",
-            expires_in = 60,
+            expires_in = 100,
             scope = "scope_per_request"
         };
 
@@ -295,7 +295,7 @@ public class ClientTokenManagementTests
         {
             access_token = "access_token",
             token_type = "token_type",
-            expires_in = 60,
+            expires_in = 100,
             scope = "scope"
         };
 
@@ -348,7 +348,7 @@ public class ClientTokenManagementTests
         {
             access_token = "access_token",
             token_type = "token_type",
-            expires_in = 60,
+            expires_in = 100,
             scope = "scope"
         };
 
@@ -410,7 +410,7 @@ public class ClientTokenManagementTests
         {
             access_token = "access_token",
             token_type = "token_type",
-            expires_in = 60,
+            expires_in = 100,
             scope = "scope"
         };
 

--- a/access-token-management/test/AccessTokenManagement.Tests/HybridCacheExplorationTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/HybridCacheExplorationTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Duende.AccessTokenManagement.Tests;
+
+public class HybridCacheExplorationTests
+{
+    [Fact]
+    public async Task Exception_is_not_written_to_cache()
+    {
+        var services = new ServiceCollection()
+            .AddHybridCache()
+            .Services;
+
+        var cache = services.BuildServiceProvider()
+            .GetRequiredService<HybridCache>();
+
+        int count = 0;
+        object item;
+
+        try
+        {
+            item = await cache.GetOrCreateAsync<object>("key", (_) =>
+            {
+                count++;
+                throw new InvalidOperationException();
+            });
+        }
+        catch (InvalidOperationException)
+        {
+
+        }
+        item = await cache.GetOrCreateAsync<object>("key", (_) =>
+        {
+            count++;
+            return ValueTask.FromResult<object>(null);
+        });
+
+        item.ShouldBeNull();
+        count.ShouldBe(2);
+    }
+}

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/DPoP/DPoPServiceCollectionExtensions.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/DPoP/DPoPServiceCollectionExtensions.cs
@@ -15,6 +15,8 @@ static class DPoPServiceCollectionExtensions
 
         services.AddTransient<DPoPJwtBearerEvents>();
         services.AddTransient<DPoPProofValidator>();
+        services.AddDistributedMemoryCache();
+
         services.AddTransient<IReplayCache, DefaultReplayCache>();
 
         services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>>(new ConfigureJwtBearerOptions(scheme));

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/DPoP/DPoPServiceCollectionExtensions.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/Framework/DPoP/DPoPServiceCollectionExtensions.cs
@@ -15,7 +15,6 @@ static class DPoPServiceCollectionExtensions
 
         services.AddTransient<DPoPJwtBearerEvents>();
         services.AddTransient<DPoPProofValidator>();
-        services.AddDistributedMemoryCache();
         services.AddTransient<IReplayCache, DefaultReplayCache>();
 
         services.AddSingleton<IPostConfigureOptions<JwtBearerOptions>>(new ConfigureJwtBearerOptions(scheme));


### PR DESCRIPTION
ATM now uses HybridCache, including the ability to use DI to use a custom instance of HybridCache. 

Before, we were writing things into IDistributedCache. Some of our clients want more direct control over where (and how) to write cache entries. For example, you may want to encrypt access tokens before they are written to a distributed cache. 

We looked into several approaches for this, such as https://github.com/DuendeSoftware/foss/pull/134.

However, now that HybridCache is introduced in .net 9 (and it's also usable in .net 8), we can use this functionality as well. 

There are some challenges with using HybridCache:

1. HybridCache doesn't yet support 'GetOrDefault' semantics. https://github.com/dotnet/extensions/issues/5688
2. HybridCache doesn't yet support setting the cache parameters, which allows you to control the lifetime of cached items on write. https://github.com/dotnet/extensions/issues/6089
3. HybridCache doesn't directly allow you to add multiple instances of HybridCache to your container. https://github.com/dotnet/extensions/issues/6026

There are 2 options:

1. (first commit). Use GetOrCreate. This has several downsides, IE: we can't cache the token for the lifetime of the token. 
2. (second commit) Use a custom implementation of GetOrDefault. There is a risk of L1 Cache misses, but L2 Cache hits. This PR also tries to compensate for this. 

fixes: https://github.com/DuendeSoftware/foss/issues/50