### PR TITLE
Fix sample aud to follow RFC 7523 bis

### DIFF
--- a/access-token-management/samples/WebJarJwt/ClientAssertionService.cs
+++ b/access-token-management/samples/WebJarJwt/ClientAssertionService.cs
@@ -50,7 +50,7 @@ public class ClientAssertionService : IClientAssertionService
         var descriptor = new SecurityTokenDescriptor
         {
             Issuer = config.ClientId,
-            Audience = config.TokenEndpoint,
+            Audience = config.Authority,
             Expires = DateTime.UtcNow.AddMinutes(1),
             SigningCredentials = Credential,
 


### PR DESCRIPTION
Use the authority instead of the token endpoint for the audience in the private_key_jwt assertion.

