### PR TITLE
Fix issue with PrepareLogoutAsync with null LogoutRequest

### DIFF
--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
@@ -101,10 +101,12 @@ internal class AuthorizeClient
         };
 
         if (_options.ProviderInformation.PushedAuthorizationRequestEndpoint.IsPresent() &&
-           !_options.DisablePushedAuthorization)
+            !_options.DisablePushedAuthorization)
         {
-            _logger.LogDebug("The IdentityProvider contains a pushed authorization request endpoint. Automatically pushing authorization parameters. Use DisablePushedAuthorization to opt out.");
-            var parResponse = await PushAuthorizationRequestAsync(state.State, pkce.CodeChallenge, frontChannelParameters);
+            _logger.LogDebug(
+                "The IdentityProvider contains a pushed authorization request endpoint. Automatically pushing authorization parameters. Use DisablePushedAuthorization to opt out.");
+            var parResponse =
+                await PushAuthorizationRequestAsync(state.State, pkce.CodeChallenge, frontChannelParameters);
             if (parResponse.IsError)
             {
                 _logger.LogError("Failed to push authorization parameters");
@@ -113,6 +115,7 @@ internal class AuthorizeClient
                 state.ErrorDescription = "Failed to push authorization parameters";
                 return state;
             }
+
             state.StartUrl = CreateAuthorizeUrl(parResponse.RequestUri, _options.ClientId);
         }
         else
@@ -125,7 +128,8 @@ internal class AuthorizeClient
         return state;
     }
 
-    private async Task<PushedAuthorizationResponse> PushAuthorizationRequestAsync(string state, string codeChallenge, Parameters frontChannelParameters)
+    private async Task<PushedAuthorizationResponse> PushAuthorizationRequestAsync(string state, string codeChallenge,
+        Parameters frontChannelParameters)
     {
         var http = _options.CreateClient();
         var par = new PushedAuthorizationRequest

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Client;

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Duende Software. All rights reserved.
+﻿// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Client;
@@ -176,9 +176,9 @@ internal class AuthorizeClient
         _logger.LogTrace("CreateEndSessionUrl");
 
         return new RequestUrl(endpoint).CreateEndSessionUrl(
-            idTokenHint: request.IdTokenHint,
+            idTokenHint: request?.IdTokenHint,
             postLogoutRedirectUri: _options.PostLogoutRedirectUri,
-            state: request.State);
+            state: request?.State);
     }
 
     internal Parameters CreateAuthorizeParameters(

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/OidcClientTests.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/OidcClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Duende Software. All rights reserved.
+// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Client;

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/OidcClientTests.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/OidcClientTests.cs
@@ -80,7 +80,9 @@ public class OidcClientTests
     class FakeHttpMessageHandler : HttpMessageHandler
     {
         public Func<HttpRequestMessage, Task<HttpResponseMessage>> Func { get; set; }
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        => Func(request);
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Func(request);
     }
 }

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/OidcClientTests.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/OidcClientTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Duende Software. All rights reserved.
+﻿// Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.IdentityModel.Client;
@@ -57,6 +57,24 @@ public class OidcClientTests
         var result = await sut.RefreshTokenAsync("test", scope: scope);
 
         result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task PrepareLogoutAsync_with_no_idtokenhint_should_work()
+    {
+        var options = new OidcClientOptions
+        {
+            Authority = "https://demo.duendesoftware.com/",
+            ClientId = "interactive.public",
+            Scope = "openid profile email offline_access",
+            RedirectUri = "test:/sign-in:",
+            PostLogoutRedirectUri = "test//sign-out:"
+        };
+
+        var client = new OidcClient(options);
+        var state = await client.PrepareLogoutAsync();
+
+        state.ShouldNotBeNull();
     }
 
     class FakeHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
Updated `CreateEndSessionUrl` to handle null `IdTokenHint` and added a test for logout preparation without an ID token hint.

**What issue does this PR address?**

The `PrepareLogoutAsync` method throws if no `LogoutRequest` is provided. This is incorrect, as the LogoutRequest is optional. The internal code is now more defensive to match the public facing API.


