### PR TITLE
Make public api surface obsolete.

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
@@ -12,6 +12,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Token store using the ASP.NET Core authentication session
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class AuthenticationSessionUserAccessTokenStore(
     IHttpContextAccessor contextAccessor,
     IStoreTokensInAuthenticationProperties tokensInProps,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/AuthenticationSessionUserTokenStore.cs
@@ -12,7 +12,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Token store using the ASP.NET Core authentication session
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class AuthenticationSessionUserAccessTokenStore(
     IHttpContextAccessor contextAccessor,
     IStoreTokensInAuthenticationProperties tokensInProps,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/BlazorServerPrincipalAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/BlazorServerPrincipalAccessor.cs
@@ -12,7 +12,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Accesses the current user from blazor server.  
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class BlazorServerUserAccessor(
     // We use the CircuitServicesAccessor to resolve the
     // AuthenticationStateProvider, rather than injecting it. Injecting the

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/BlazorServerPrincipalAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/BlazorServerPrincipalAccessor.cs
@@ -12,6 +12,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Accesses the current user from blazor server.  
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class BlazorServerUserAccessor(
     // We use the CircuitServicesAccessor to resolve the
     // AuthenticationStateProvider, rather than injecting it. Injecting the

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/CircuitServicesAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/CircuitServicesAccessor.cs
@@ -13,6 +13,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// Provides access to scoped blazor services from non-blazor DI scopes, such as
 /// scopes created using IHttpClientFactory.
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class CircuitServicesAccessor
 {
     static readonly AsyncLocal<IServiceProvider> BlazorServices = new();
@@ -26,7 +27,9 @@ public class CircuitServicesAccessor
 
 internal class ServicesAccessorCircuitHandler(
     IServiceProvider services,
+#pragma warning disable CS0618 // Type or member is obsolete
     CircuitServicesAccessor servicesAccessor)
+#pragma warning restore CS0618 // Type or member is obsolete
     : CircuitHandler
 {
     public override Func<CircuitInboundActivityContext, Task> CreateInboundActivityHandler(
@@ -46,7 +49,9 @@ internal static class CircuitServicesServiceCollectionExtensions
     public static IServiceCollection AddCircuitServicesAccessor(
         this IServiceCollection services)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         services.AddScoped<CircuitServicesAccessor>();
+#pragma warning restore CS0618 // Type or member is obsolete
         services.AddScoped<CircuitHandler, ServicesAccessorCircuitHandler>();
 
         return services;

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/CircuitServicesAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/CircuitServicesAccessor.cs
@@ -13,7 +13,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// Provides access to scoped blazor services from non-blazor DI scopes, such as
 /// scopes created using IHttpClientFactory.
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class CircuitServicesAccessor
 {
     static readonly AsyncLocal<IServiceProvider> BlazorServices = new();

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/HttpContextPrincipalAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/HttpContextPrincipalAccessor.cs
@@ -9,7 +9,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Accesses the current principal based on the HttpContext.User.
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class HttpContextUserAccessor : IUserAccessor
 {
     private readonly IHttpContextAccessor _httpContextAccessor;

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/HttpContextPrincipalAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/HttpContextPrincipalAccessor.cs
@@ -9,6 +9,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Accesses the current principal based on the HttpContext.User.
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class HttpContextUserAccessor : IUserAccessor
 {
     private readonly IHttpContextAccessor _httpContextAccessor;

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
@@ -10,7 +10,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Delegating handler that injects the current access token into an outgoing request
 /// </summary>
-[Obsolete("This type is going to be made internal in future releases.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class OpenIdConnectClientAccessTokenHandler(
     IDPoPProofService dPoPProofService,
     IDPoPNonceStore dPoPNonceStore,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectClientAccessTokenHandler.cs
@@ -10,6 +10,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Delegating handler that injects the current access token into an outgoing request
 /// </summary>
+[Obsolete("This type is going to be made internal in future releases.")]
 public class OpenIdConnectClientAccessTokenHandler(
     IDPoPProofService dPoPProofService,
     IDPoPNonceStore dPoPNonceStore,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
@@ -9,7 +9,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 namespace Duende.AccessTokenManagement.OpenIdConnect;
 
 /// <inheritdoc />
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class OpenIdConnectConfigurationService(
     IOptions<UserTokenManagementOptions> userAccessTokenManagementOptions,
     IOptionsMonitor<OpenIdConnectOptions> oidcOptionsMonitor,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectConfigurationService.cs
@@ -9,6 +9,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 namespace Duende.AccessTokenManagement.OpenIdConnect;
 
 /// <inheritdoc />
+[Obsolete("This type is going to be removed in a future release.")]
 public class OpenIdConnectConfigurationService(
     IOptions<UserTokenManagementOptions> userAccessTokenManagementOptions,
     IOptionsMonitor<OpenIdConnectOptions> oidcOptionsMonitor,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectTokenManagementServiceCollectionExtensions.cs
@@ -31,7 +31,9 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
         // for example, per-scheme client credentials style, scope, etc settings
 
         services.TryAddTransient<IUserTokenManagementService, UserAccessAccessTokenManagementService>();
+#pragma warning disable CS0618 // Type or member is obsolete
         services.TryAddTransient<IOpenIdConnectConfigurationService, OpenIdConnectConfigurationService>();
+#pragma warning restore CS0618 // Type or member is obsolete
         services.TryAddSingleton<IUserTokenRequestSynchronization, UserTokenRequestSynchronization>();
         services.TryAddTransient<IUserTokenEndpointService, UserTokenEndpointService>();
 
@@ -43,8 +45,11 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
         // where we can use the http context. The services below depend on http
         // context, and we register different ones in blazor
 
+#pragma warning disable CS0618 // Type or member is obsolete
         services.TryAddScoped<IUserAccessor, HttpContextUserAccessor>();
         services.TryAddScoped<IUserTokenStore, AuthenticationSessionUserAccessTokenStore>();
+#pragma warning restore CS0618 // Type or member is obsolete
+
         // scoped since it will be caching per-request authentication results
         services.AddScoped<AuthenticateResultCache>();
 
@@ -63,7 +68,9 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
         where TTokenStore : class, IUserTokenStore
     {
         services.AddScoped<IUserTokenStore, TTokenStore>();
+#pragma warning disable CS0618 // Type or member is obsolete
         services.AddScoped<IUserAccessor, BlazorServerUserAccessor>();
+#pragma warning restore CS0618 // Type or member is obsolete
         services.AddCircuitServicesAccessor();
         services.AddHttpContextAccessor(); // For SSR
 
@@ -211,11 +218,15 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
             var dpopService = provider.GetRequiredService<IDPoPProofService>();
             var dpopNonceStore = provider.GetRequiredService<IDPoPNonceStore>();
             var userTokenManagement = provider.GetRequiredService<IUserTokenManagementService>();
+#pragma warning disable CS0618 // Type or member is obsolete
             var logger = provider.GetRequiredService<ILogger<OpenIdConnectClientAccessTokenHandler>>();
             var principalAccessor = provider.GetRequiredService<IUserAccessor>();
 
             return new OpenIdConnectUserAccessTokenHandler(
                 dpopService, dpopNonceStore, principalAccessor, userTokenManagement, logger, parameters);
+
+#pragma warning restore CS0618 // Type or member is obsolete
+
         });
     }
 
@@ -234,9 +245,12 @@ public static class OpenIdConnectTokenManagementServiceCollectionExtensions
             var dpopService = provider.GetRequiredService<IDPoPProofService>();
             var dpopNonceStore = provider.GetRequiredService<IDPoPNonceStore>();
             var contextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+#pragma warning disable CS0618 // Type or member is obsolete
             var logger = provider.GetRequiredService<ILogger<OpenIdConnectClientAccessTokenHandler>>();
 
             return new OpenIdConnectClientAccessTokenHandler(dpopService, dpopNonceStore, contextAccessor, logger, parameters);
+#pragma warning restore CS0618 // Type or member is obsolete
+
         });
     }
 }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectUserAccessTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectUserAccessTokenHandler.cs
@@ -8,7 +8,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Delegating handler that injects the current access token into an outgoing request
 /// </summary>
-[Obsolete("This type is going to be made internal in future releases.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class OpenIdConnectUserAccessTokenHandler(
     IDPoPProofService dPoPProofService,
     IDPoPNonceStore dPoPNonceStore,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectUserAccessTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectUserAccessTokenHandler.cs
@@ -8,6 +8,7 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// <summary>
 /// Delegating handler that injects the current access token into an outgoing request
 /// </summary>
+[Obsolete("This type is going to be made internal in future releases.")]
 public class OpenIdConnectUserAccessTokenHandler(
     IDPoPProofService dPoPProofService,
     IDPoPNonceStore dPoPNonceStore,

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
@@ -11,7 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Implements token endpoint operations using IdentityModel
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class ClientCredentialsTokenEndpointService(
     IHttpClientFactory httpClientFactory,
     IOptionsMonitor<ClientCredentialsClient> options,

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
@@ -11,6 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Implements token endpoint operations using IdentityModel
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class ClientCredentialsTokenEndpointService(
     IHttpClientFactory httpClientFactory,
     IOptionsMonitor<ClientCredentialsClient> options,

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenHandler.cs
@@ -8,7 +8,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Delegating handler that injects a client credentials access token into an outgoing request
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class ClientCredentialsTokenHandler(
     IDPoPProofService dPoPProofService,
     IDPoPNonceStore dPoPNonceStore,

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenHandler.cs
@@ -8,6 +8,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Delegating handler that injects a client credentials access token into an outgoing request
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class ClientCredentialsTokenHandler(
     IDPoPProofService dPoPProofService,
     IDPoPNonceStore dPoPNonceStore,

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementBuilder.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementBuilder.cs
@@ -31,11 +31,14 @@ public class ClientCredentialsTokenManagementBuilder(IServiceCollection services
     public ClientCredentialsTokenManagementBuilder UsePreviewHybridCache()
     {
         // Replace the default implementations with the hybrid cache versions
+#pragma warning disable CS0618 // Type or member is obsolete
         RemoveDefaultRegistration<IClientCredentialsTokenCache, DistributedClientCredentialsTokenCache>();
         Services.AddTransient<IClientCredentialsTokenCache, HybridClientCredentialsTokenCache>();
 
         RemoveDefaultRegistration<IDPoPNonceStore, DistributedDPoPNonceStore>();
         Services.AddTransient<IDPoPNonceStore, HybridDPoPNonceStore>();
+
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // Make sure the hybrid cache is registered. If this is registered by the user, this will be a no-op
         Services.AddHybridCache();

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
@@ -6,7 +6,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Implements token management logic
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class ClientCredentialsTokenManagementService(
     IClientCredentialsTokenEndpointService clientCredentialsTokenEndpointService,
     IClientCredentialsTokenCache tokenCache) : IClientCredentialsTokenManagementService

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementService.cs
@@ -6,6 +6,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Implements token management logic
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class ClientCredentialsTokenManagementService(
     IClientCredentialsTokenEndpointService clientCredentialsTokenEndpointService,
     IClientCredentialsTokenCache tokenCache) : IClientCredentialsTokenManagementService

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementServiceCollectionExtensions.cs
@@ -37,9 +37,9 @@ public static class ClientCredentialsTokenManagementServiceCollectionExtensions
     {
         services.TryAddSingleton<ITokenRequestSynchronization, TokenRequestSynchronization>();
 
+#pragma warning disable CS0618 // Type or member is obsolete
         services.TryAddTransient<IClientCredentialsTokenManagementService, ClientCredentialsTokenManagementService>();
 
-        services.TryAddSingleton(TimeProvider.System);
 
         // By default, resolve the distributed cache for the DistributedClientCredentialsTokenCache
         // without key. If desired, a consumers can register the distributed cache with a key
@@ -56,6 +56,10 @@ public static class ClientCredentialsTokenManagementServiceCollectionExtensions
         // without key. If desired, a consumers can register the distributed cache with a key
         services.TryAddKeyedSingleton<IDistributedCache>(ServiceProviderKeys.DPoPNonceStore, (sp, _) => sp.GetRequiredService<IDistributedCache>());
         services.TryAddTransient<IDPoPNonceStore, DistributedDPoPNonceStore>();
+
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        services.TryAddSingleton(TimeProvider.System);
 
         services.AddHttpClient(ClientCredentialsTokenManagementDefaults.BackChannelHttpClientName);
 
@@ -121,9 +125,12 @@ public static class ClientCredentialsTokenManagementServiceCollectionExtensions
             var dpopService = provider.GetRequiredService<IDPoPProofService>();
             var dpopNonceStore = provider.GetRequiredService<IDPoPNonceStore>();
             var accessTokenManagementService = provider.GetRequiredService<IClientCredentialsTokenManagementService>();
+#pragma warning disable CS0618 // Type or member is obsolete
             var logger = provider.GetRequiredService<ILogger<ClientCredentialsTokenHandler>>();
 
             return new ClientCredentialsTokenHandler(dpopService, dpopNonceStore, accessTokenManagementService, logger, tokenClientName);
+#pragma warning restore CS0618 // Type or member is obsolete
+
         });
     }
 }

--- a/access-token-management/src/AccessTokenManagement/Constants.cs
+++ b/access-token-management/src/AccessTokenManagement/Constants.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Duende.AccessTokenManagement;
+
+internal class Constants
+{
+    public const string AtmPublicSurfaceInternal =
+        "This will be made internal or removed in a future version. If you are using this type directly, please see " + AtmPublicSurfaceLink;
+
+    public const string AtmPublicSurfaceLink = "https://duende.link/aacs4dq";
+}

--- a/access-token-management/src/AccessTokenManagement/DefaultClientAssertionService.cs
+++ b/access-token-management/src/AccessTokenManagement/DefaultClientAssertionService.cs
@@ -6,6 +6,7 @@ using Duende.IdentityModel.Client;
 namespace Duende.AccessTokenManagement;
 
 /// <inheritdoc />
+[Obsolete("This type is going to be removed in a future release.")]
 public class DefaultClientAssertionService : IClientAssertionService
 {
     /// <inheritdoc />

--- a/access-token-management/src/AccessTokenManagement/DefaultClientAssertionService.cs
+++ b/access-token-management/src/AccessTokenManagement/DefaultClientAssertionService.cs
@@ -6,7 +6,7 @@ using Duende.IdentityModel.Client;
 namespace Duende.AccessTokenManagement;
 
 /// <inheritdoc />
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class DefaultClientAssertionService : IClientAssertionService
 {
     /// <inheritdoc />

--- a/access-token-management/src/AccessTokenManagement/DefaultDPoPKeyStore.cs
+++ b/access-token-management/src/AccessTokenManagement/DefaultDPoPKeyStore.cs
@@ -8,6 +8,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Default implementation
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class DefaultDPoPKeyStore(IOptionsMonitor<ClientCredentialsClient> options) : IDPoPKeyStore
 {
     /// <inheritdoc/>

--- a/access-token-management/src/AccessTokenManagement/DefaultDPoPKeyStore.cs
+++ b/access-token-management/src/AccessTokenManagement/DefaultDPoPKeyStore.cs
@@ -8,7 +8,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Default implementation
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class DefaultDPoPKeyStore(IOptionsMonitor<ClientCredentialsClient> options) : IDPoPKeyStore
 {
     /// <inheritdoc/>

--- a/access-token-management/src/AccessTokenManagement/DefaultDPoPProofService.cs
+++ b/access-token-management/src/AccessTokenManagement/DefaultDPoPProofService.cs
@@ -14,7 +14,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Default implementation of IDPoPProofService
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class DefaultDPoPProofService(IDPoPNonceStore dPoPNonceStore, ILogger<DefaultDPoPProofService> logger) : IDPoPProofService
 {
     /// <inheritdoc/>

--- a/access-token-management/src/AccessTokenManagement/DefaultDPoPProofService.cs
+++ b/access-token-management/src/AccessTokenManagement/DefaultDPoPProofService.cs
@@ -14,6 +14,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Default implementation of IDPoPProofService
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class DefaultDPoPProofService(IDPoPNonceStore dPoPNonceStore, ILogger<DefaultDPoPProofService> logger) : IDPoPProofService
 {
     /// <inheritdoc/>

--- a/access-token-management/src/AccessTokenManagement/DistributedClientCredentialsTokenCache.cs
+++ b/access-token-management/src/AccessTokenManagement/DistributedClientCredentialsTokenCache.cs
@@ -11,7 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Client access token cache using IDistributedCache
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class DistributedClientCredentialsTokenCache(
     [FromKeyedServices(ServiceProviderKeys.ClientCredentialsTokenCache)] IDistributedCache cache,
     ITokenRequestSynchronization synchronization,

--- a/access-token-management/src/AccessTokenManagement/DistributedClientCredentialsTokenCache.cs
+++ b/access-token-management/src/AccessTokenManagement/DistributedClientCredentialsTokenCache.cs
@@ -11,6 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// Client access token cache using IDistributedCache
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class DistributedClientCredentialsTokenCache(
     [FromKeyedServices(ServiceProviderKeys.ClientCredentialsTokenCache)] IDistributedCache cache,
     ITokenRequestSynchronization synchronization,

--- a/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
+++ b/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
@@ -11,7 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// DPoP nonce store using IDistributedCache
 /// </summary>
-[Obsolete("This type is going to be removed in a future release.")]
+[Obsolete(Constants.AtmPublicSurfaceInternal, UrlFormat = Constants.AtmPublicSurfaceLink)]
 public class DistributedDPoPNonceStore(
     [FromKeyedServices(ServiceProviderKeys.DPoPNonceStore)] IDistributedCache cache,
     IOptions<ClientCredentialsTokenManagementOptions> options,
@@ -62,7 +62,7 @@ public class DistributedDPoPNonceStore(
     /// <summary>
     /// Generates the cache key based on various inputs
     /// </summary>
-    [Obsolete("This method is deprecated and will be removed in future versions. ")]
+    [Obsolete("This method is deprecated and will be removed in a future version. To customize CacheKeyGeneration, please use the property ClientCredentialsTokenManagementOptions.GenerateNonceStoreKey")]
     protected virtual string GenerateCacheKey(DPoPNonceContext context)
     {
         return options.Value.GenerateNonceStoreKey(context);

--- a/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
+++ b/access-token-management/src/AccessTokenManagement/DistributedDPoPNonceStore.cs
@@ -11,6 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// DPoP nonce store using IDistributedCache
 /// </summary>
+[Obsolete("This type is going to be removed in a future release.")]
 public class DistributedDPoPNonceStore(
     [FromKeyedServices(ServiceProviderKeys.DPoPNonceStore)] IDistributedCache cache,
     IOptions<ClientCredentialsTokenManagementOptions> options,

--- a/access-token-management/src/AccessTokenManagement/DuendeAccessTokenSerializationContext.cs
+++ b/access-token-management/src/AccessTokenManagement/DuendeAccessTokenSerializationContext.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json.Serialization;
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
 
 namespace Duende.AccessTokenManagement;
 

--- a/access-token-management/src/AccessTokenManagement/HybridDPoPNonceStore.cs
+++ b/access-token-management/src/AccessTokenManagement/HybridDPoPNonceStore.cs
@@ -11,7 +11,7 @@ namespace Duende.AccessTokenManagement;
 /// <summary>
 /// DPoP nonce store using IDistributedCache
 /// </summary>
-public class HybridDPoPNonceStore(
+internal class HybridDPoPNonceStore(
     [FromKeyedServices(ServiceProviderKeys.DPoPNonceStore)] HybridCache cache,
     IOptions<ClientCredentialsTokenManagementOptions> options,
     ILogger<HybridDPoPNonceStore> logger) : IDPoPNonceStore

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -36,11 +36,13 @@
         public bool IsError { get; }
         public string? Scope { get; set; }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class ClientCredentialsTokenEndpointService : Duende.AccessTokenManagement.IClientCredentialsTokenEndpointService
     {
         public ClientCredentialsTokenEndpointService(System.Net.Http.IHttpClientFactory httpClientFactory, Microsoft.Extensions.Options.IOptionsMonitor<Duende.AccessTokenManagement.ClientCredentialsClient> options, Duende.AccessTokenManagement.IClientAssertionService clientAssertionService, Duende.AccessTokenManagement.IDPoPKeyStore dPoPKeyMaterialService, Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.ClientCredentialsTokenEndpointService> logger) { }
         public virtual System.Threading.Tasks.Task<Duende.AccessTokenManagement.ClientCredentialsToken> RequestToken(string clientName, Duende.AccessTokenManagement.TokenRequestParameters? parameters = null, System.Threading.CancellationToken cancellationToken = default) { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class ClientCredentialsTokenHandler : Duende.AccessTokenManagement.AccessTokenHandler
     {
         public ClientCredentialsTokenHandler(Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Duende.AccessTokenManagement.IClientCredentialsTokenManagementService accessTokenManagementService, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.ClientCredentialsTokenHandler> logger, string tokenClientName) { }
@@ -61,6 +63,7 @@
         public Duende.AccessTokenManagement.DPoPNonceStoreKeyGenerator GenerateNonceStoreKey { get; }
         public string NonceStoreKeyPrefix { get; set; }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class ClientCredentialsTokenManagementService : Duende.AccessTokenManagement.IClientCredentialsTokenManagementService
     {
         public ClientCredentialsTokenManagementService(Duende.AccessTokenManagement.IClientCredentialsTokenEndpointService clientCredentialsTokenEndpointService, Duende.AccessTokenManagement.IClientCredentialsTokenCache tokenCache) { }
@@ -123,22 +126,26 @@
         [System.Runtime.CompilerServices.RequiredMember]
         public string Url { get; set; }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class DefaultClientAssertionService : Duende.AccessTokenManagement.IClientAssertionService
     {
         public DefaultClientAssertionService() { }
         public System.Threading.Tasks.Task<Duende.IdentityModel.Client.ClientAssertion?> GetClientAssertionAsync(string? clientName = null, Duende.AccessTokenManagement.TokenRequestParameters? parameters = null) { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class DefaultDPoPKeyStore : Duende.AccessTokenManagement.IDPoPKeyStore
     {
         public DefaultDPoPKeyStore(Microsoft.Extensions.Options.IOptionsMonitor<Duende.AccessTokenManagement.ClientCredentialsClient> options) { }
         public virtual System.Threading.Tasks.Task<Duende.AccessTokenManagement.DPoPKey?> GetKeyAsync(string clientName) { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class DefaultDPoPProofService : Duende.AccessTokenManagement.IDPoPProofService
     {
         public DefaultDPoPProofService(Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.DefaultDPoPProofService> logger) { }
         public virtual System.Threading.Tasks.Task<Duende.AccessTokenManagement.DPoPProof?> CreateProofTokenAsync(Duende.AccessTokenManagement.DPoPProofRequest request) { }
         public virtual string? GetProofKeyThumbprint(Duende.AccessTokenManagement.DPoPProofRequest request) { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class DistributedClientCredentialsTokenCache : Duende.AccessTokenManagement.IClientCredentialsTokenCache
     {
         public DistributedClientCredentialsTokenCache([Microsoft.Extensions.DependencyInjection.FromKeyedServices("ClientCredentialsTokenCache")] Microsoft.Extensions.Caching.Distributed.IDistributedCache cache, Duende.AccessTokenManagement.ITokenRequestSynchronization synchronization, Microsoft.Extensions.Options.IOptions<Duende.AccessTokenManagement.ClientCredentialsTokenManagementOptions> options, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.DistributedClientCredentialsTokenCache> logger) { }
@@ -151,6 +158,7 @@
         public System.Threading.Tasks.Task<Duende.AccessTokenManagement.ClientCredentialsToken> GetOrCreateAsync(string clientName, Duende.AccessTokenManagement.TokenRequestParameters requestParameters, System.Func<string, Duende.AccessTokenManagement.TokenRequestParameters, System.Threading.CancellationToken, System.Threading.Tasks.Task<Duende.AccessTokenManagement.ClientCredentialsToken>> factory, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task SetAsync(string clientName, Duende.AccessTokenManagement.ClientCredentialsToken clientCredentialsToken, Duende.AccessTokenManagement.TokenRequestParameters requestParameters, System.Threading.CancellationToken cancellationToken = default) { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class DistributedDPoPNonceStore : Duende.AccessTokenManagement.IDPoPNonceStore
     {
         public DistributedDPoPNonceStore([Microsoft.Extensions.DependencyInjection.FromKeyedServices("DPoPNonceStore")] Microsoft.Extensions.Caching.Distributed.IDistributedCache cache, Microsoft.Extensions.Options.IOptions<Duende.AccessTokenManagement.ClientCredentialsTokenManagementOptions> options, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.DistributedDPoPNonceStore> logger) { }
@@ -180,12 +188,6 @@
     public static class HybridCacheExtMethods
     {
         public static System.Threading.Tasks.ValueTask<T?> GetOrDefaultAsync<T>(this Microsoft.Extensions.Caching.Hybrid.HybridCache cache, string key, System.Threading.CancellationToken cancellationToken = default) { }
-    }
-    public class HybridDPoPNonceStore : Duende.AccessTokenManagement.IDPoPNonceStore
-    {
-        public HybridDPoPNonceStore([Microsoft.Extensions.DependencyInjection.FromKeyedServices("DPoPNonceStore")] Microsoft.Extensions.Caching.Hybrid.HybridCache cache, Microsoft.Extensions.Options.IOptions<Duende.AccessTokenManagement.ClientCredentialsTokenManagementOptions> options, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.HybridDPoPNonceStore> logger) { }
-        public virtual System.Threading.Tasks.Task<string?> GetNonceAsync(Duende.AccessTokenManagement.DPoPNonceContext context, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.Task StoreNonceAsync(Duende.AccessTokenManagement.DPoPNonceContext context, string nonce, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public interface IClientAssertionService
     {

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -36,13 +36,15 @@
         public bool IsError { get; }
         public string? Scope { get; set; }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class ClientCredentialsTokenEndpointService : Duende.AccessTokenManagement.IClientCredentialsTokenEndpointService
     {
         public ClientCredentialsTokenEndpointService(System.Net.Http.IHttpClientFactory httpClientFactory, Microsoft.Extensions.Options.IOptionsMonitor<Duende.AccessTokenManagement.ClientCredentialsClient> options, Duende.AccessTokenManagement.IClientAssertionService clientAssertionService, Duende.AccessTokenManagement.IDPoPKeyStore dPoPKeyMaterialService, Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.ClientCredentialsTokenEndpointService> logger) { }
         public virtual System.Threading.Tasks.Task<Duende.AccessTokenManagement.ClientCredentialsToken> RequestToken(string clientName, Duende.AccessTokenManagement.TokenRequestParameters? parameters = null, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class ClientCredentialsTokenHandler : Duende.AccessTokenManagement.AccessTokenHandler
     {
         public ClientCredentialsTokenHandler(Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Duende.AccessTokenManagement.IClientCredentialsTokenManagementService accessTokenManagementService, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.ClientCredentialsTokenHandler> logger, string tokenClientName) { }
@@ -63,7 +65,8 @@
         public Duende.AccessTokenManagement.DPoPNonceStoreKeyGenerator GenerateNonceStoreKey { get; }
         public string NonceStoreKeyPrefix { get; set; }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class ClientCredentialsTokenManagementService : Duende.AccessTokenManagement.IClientCredentialsTokenManagementService
     {
         public ClientCredentialsTokenManagementService(Duende.AccessTokenManagement.IClientCredentialsTokenEndpointService clientCredentialsTokenEndpointService, Duende.AccessTokenManagement.IClientCredentialsTokenCache tokenCache) { }
@@ -126,26 +129,30 @@
         [System.Runtime.CompilerServices.RequiredMember]
         public string Url { get; set; }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class DefaultClientAssertionService : Duende.AccessTokenManagement.IClientAssertionService
     {
         public DefaultClientAssertionService() { }
         public System.Threading.Tasks.Task<Duende.IdentityModel.Client.ClientAssertion?> GetClientAssertionAsync(string? clientName = null, Duende.AccessTokenManagement.TokenRequestParameters? parameters = null) { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class DefaultDPoPKeyStore : Duende.AccessTokenManagement.IDPoPKeyStore
     {
         public DefaultDPoPKeyStore(Microsoft.Extensions.Options.IOptionsMonitor<Duende.AccessTokenManagement.ClientCredentialsClient> options) { }
         public virtual System.Threading.Tasks.Task<Duende.AccessTokenManagement.DPoPKey?> GetKeyAsync(string clientName) { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class DefaultDPoPProofService : Duende.AccessTokenManagement.IDPoPProofService
     {
         public DefaultDPoPProofService(Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.DefaultDPoPProofService> logger) { }
         public virtual System.Threading.Tasks.Task<Duende.AccessTokenManagement.DPoPProof?> CreateProofTokenAsync(Duende.AccessTokenManagement.DPoPProofRequest request) { }
         public virtual string? GetProofKeyThumbprint(Duende.AccessTokenManagement.DPoPProofRequest request) { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class DistributedClientCredentialsTokenCache : Duende.AccessTokenManagement.IClientCredentialsTokenCache
     {
         public DistributedClientCredentialsTokenCache([Microsoft.Extensions.DependencyInjection.FromKeyedServices("ClientCredentialsTokenCache")] Microsoft.Extensions.Caching.Distributed.IDistributedCache cache, Duende.AccessTokenManagement.ITokenRequestSynchronization synchronization, Microsoft.Extensions.Options.IOptions<Duende.AccessTokenManagement.ClientCredentialsTokenManagementOptions> options, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.DistributedClientCredentialsTokenCache> logger) { }
@@ -158,11 +165,14 @@
         public System.Threading.Tasks.Task<Duende.AccessTokenManagement.ClientCredentialsToken> GetOrCreateAsync(string clientName, Duende.AccessTokenManagement.TokenRequestParameters requestParameters, System.Func<string, Duende.AccessTokenManagement.TokenRequestParameters, System.Threading.CancellationToken, System.Threading.Tasks.Task<Duende.AccessTokenManagement.ClientCredentialsToken>> factory, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task SetAsync(string clientName, Duende.AccessTokenManagement.ClientCredentialsToken clientCredentialsToken, Duende.AccessTokenManagement.TokenRequestParameters requestParameters, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class DistributedDPoPNonceStore : Duende.AccessTokenManagement.IDPoPNonceStore
     {
         public DistributedDPoPNonceStore([Microsoft.Extensions.DependencyInjection.FromKeyedServices("DPoPNonceStore")] Microsoft.Extensions.Caching.Distributed.IDistributedCache cache, Microsoft.Extensions.Options.IOptions<Duende.AccessTokenManagement.ClientCredentialsTokenManagementOptions> options, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.DistributedDPoPNonceStore> logger) { }
-        [System.Obsolete("This method is deprecated and will be removed in future versions. ")]
+        [System.Obsolete(("This method is deprecated and will be removed in a future version. To customize C" +
+            "acheKeyGeneration, please use the property ClientCredentialsTokenManagementOptio" +
+            "ns.GenerateNonceStoreKey"))]
         protected virtual string GenerateCacheKey(Duende.AccessTokenManagement.DPoPNonceContext context) { }
         public virtual System.Threading.Tasks.Task<string?> GetNonceAsync(Duende.AccessTokenManagement.DPoPNonceContext context, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.Task StoreNonceAsync(Duende.AccessTokenManagement.DPoPNonceContext context, string nonce, System.Threading.CancellationToken cancellationToken = default) { }

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
@@ -1,6 +1,7 @@
 ﻿namespace Duende.AccessTokenManagement.OpenIdConnect
 {
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class AuthenticationSessionUserAccessTokenStore : Duende.AccessTokenManagement.OpenIdConnect.IUserTokenStore
     {
         public AuthenticationSessionUserAccessTokenStore(Microsoft.AspNetCore.Http.IHttpContextAccessor contextAccessor, Duende.AccessTokenManagement.OpenIdConnect.IStoreTokensInAuthenticationProperties tokensInProps, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.AuthenticationSessionUserAccessTokenStore> logger) { }
@@ -9,13 +10,15 @@
         public System.Threading.Tasks.Task<Duende.AccessTokenManagement.OpenIdConnect.UserToken> GetTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }
         public System.Threading.Tasks.Task StoreTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserToken token, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class BlazorServerUserAccessor : Duende.AccessTokenManagement.OpenIdConnect.IUserAccessor
     {
         public BlazorServerUserAccessor(Duende.AccessTokenManagement.OpenIdConnect.CircuitServicesAccessor circuitServicesAccessor, Microsoft.AspNetCore.Http.IHttpContextAccessor? httpContextAccessor, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.BlazorServerUserAccessor> logger) { }
         public System.Threading.Tasks.Task<System.Security.Claims.ClaimsPrincipal> GetCurrentUserAsync() { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class CircuitServicesAccessor
     {
         public CircuitServicesAccessor() { }
@@ -32,7 +35,8 @@
         public void Configure(Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions options) { }
         public void Configure(string? name, Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions options) { }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class HttpContextUserAccessor : Duende.AccessTokenManagement.OpenIdConnect.IUserAccessor
     {
         public HttpContextUserAccessor(Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor) { }
@@ -73,7 +77,8 @@
         System.Threading.Tasks.Task<Duende.AccessTokenManagement.OpenIdConnect.UserToken> GetTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null);
         System.Threading.Tasks.Task StoreTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserToken token, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null);
     }
-    [System.Obsolete("This type is going to be made internal in future releases.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class OpenIdConnectClientAccessTokenHandler : Duende.AccessTokenManagement.AccessTokenHandler
     {
         public OpenIdConnectClientAccessTokenHandler(Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.OpenIdConnectClientAccessTokenHandler> logger, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }
@@ -90,7 +95,8 @@
         public string? Scheme { get; set; }
         public string? TokenEndpoint { get; set; }
     }
-    [System.Obsolete("This type is going to be removed in a future release.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class OpenIdConnectConfigurationService : Duende.AccessTokenManagement.OpenIdConnect.IOpenIdConnectConfigurationService
     {
         public OpenIdConnectConfigurationService(Microsoft.Extensions.Options.IOptions<Duende.AccessTokenManagement.OpenIdConnect.UserTokenManagementOptions> userAccessTokenManagementOptions, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions> oidcOptionsMonitor, Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider schemeProvider) { }
@@ -100,7 +106,8 @@
     {
         public const string ClientCredentialsClientNamePrefix = "Duende.TokenManagement.SchemeBasedClient:";
     }
-    [System.Obsolete("This type is going to be made internal in future releases.")]
+    [System.Obsolete(("This will be made internal or removed in a future version. If you are using this " +
+        "type directly, please see https://duende.link/aacs4dq"), UrlFormat="https://duende.link/aacs4dq")]
     public class OpenIdConnectUserAccessTokenHandler : Duende.AccessTokenManagement.AccessTokenHandler
     {
         public OpenIdConnectUserAccessTokenHandler(Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Duende.AccessTokenManagement.OpenIdConnect.IUserAccessor userAccessor, Duende.AccessTokenManagement.OpenIdConnect.IUserTokenManagementService userTokenManagement, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.OpenIdConnectClientAccessTokenHandler> logger, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
@@ -1,5 +1,6 @@
 ﻿namespace Duende.AccessTokenManagement.OpenIdConnect
 {
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class AuthenticationSessionUserAccessTokenStore : Duende.AccessTokenManagement.OpenIdConnect.IUserTokenStore
     {
         public AuthenticationSessionUserAccessTokenStore(Microsoft.AspNetCore.Http.IHttpContextAccessor contextAccessor, Duende.AccessTokenManagement.OpenIdConnect.IStoreTokensInAuthenticationProperties tokensInProps, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.AuthenticationSessionUserAccessTokenStore> logger) { }
@@ -8,11 +9,13 @@
         public System.Threading.Tasks.Task<Duende.AccessTokenManagement.OpenIdConnect.UserToken> GetTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }
         public System.Threading.Tasks.Task StoreTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserToken token, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class BlazorServerUserAccessor : Duende.AccessTokenManagement.OpenIdConnect.IUserAccessor
     {
         public BlazorServerUserAccessor(Duende.AccessTokenManagement.OpenIdConnect.CircuitServicesAccessor circuitServicesAccessor, Microsoft.AspNetCore.Http.IHttpContextAccessor? httpContextAccessor, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.BlazorServerUserAccessor> logger) { }
         public System.Threading.Tasks.Task<System.Security.Claims.ClaimsPrincipal> GetCurrentUserAsync() { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class CircuitServicesAccessor
     {
         public CircuitServicesAccessor() { }
@@ -29,6 +32,7 @@
         public void Configure(Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions options) { }
         public void Configure(string? name, Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions options) { }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class HttpContextUserAccessor : Duende.AccessTokenManagement.OpenIdConnect.IUserAccessor
     {
         public HttpContextUserAccessor(Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor) { }
@@ -69,6 +73,7 @@
         System.Threading.Tasks.Task<Duende.AccessTokenManagement.OpenIdConnect.UserToken> GetTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null);
         System.Threading.Tasks.Task StoreTokenAsync(System.Security.Claims.ClaimsPrincipal user, Duende.AccessTokenManagement.OpenIdConnect.UserToken token, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null);
     }
+    [System.Obsolete("This type is going to be made internal in future releases.")]
     public class OpenIdConnectClientAccessTokenHandler : Duende.AccessTokenManagement.AccessTokenHandler
     {
         public OpenIdConnectClientAccessTokenHandler(Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.OpenIdConnectClientAccessTokenHandler> logger, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }
@@ -85,6 +90,7 @@
         public string? Scheme { get; set; }
         public string? TokenEndpoint { get; set; }
     }
+    [System.Obsolete("This type is going to be removed in a future release.")]
     public class OpenIdConnectConfigurationService : Duende.AccessTokenManagement.OpenIdConnect.IOpenIdConnectConfigurationService
     {
         public OpenIdConnectConfigurationService(Microsoft.Extensions.Options.IOptions<Duende.AccessTokenManagement.OpenIdConnect.UserTokenManagementOptions> userAccessTokenManagementOptions, Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions> oidcOptionsMonitor, Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider schemeProvider) { }
@@ -94,6 +100,7 @@
     {
         public const string ClientCredentialsClientNamePrefix = "Duende.TokenManagement.SchemeBasedClient:";
     }
+    [System.Obsolete("This type is going to be made internal in future releases.")]
     public class OpenIdConnectUserAccessTokenHandler : Duende.AccessTokenManagement.AccessTokenHandler
     {
         public OpenIdConnectUserAccessTokenHandler(Duende.AccessTokenManagement.IDPoPProofService dPoPProofService, Duende.AccessTokenManagement.IDPoPNonceStore dPoPNonceStore, Duende.AccessTokenManagement.OpenIdConnect.IUserAccessor userAccessor, Duende.AccessTokenManagement.OpenIdConnect.IUserTokenManagementService userTokenManagement, Microsoft.Extensions.Logging.ILogger<Duende.AccessTokenManagement.OpenIdConnect.OpenIdConnectClientAccessTokenHandler> logger, Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters? parameters = null) { }


### PR DESCRIPTION
**What issue does this PR address?**

All the implementation classes have received an obsolete attribute. 

Currently, all the implementation types are public. This means that there is a great chance of breaking changes when implementing changes in this library. To help with this, we're planning to make our implementation types internal and move to explicit extensibility points. 

To make sure we expose the right extensibility points, a discussion is opened here:
https://github.com/orgs/DuendeSoftware/discussions/140


