### PR TITLE
Added constant for new fields for RFC 9701

### DIFF
--- a/identity-model/src/IdentityModel/Client/Messages/DiscoveryDocumentResponse.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/DiscoveryDocumentResponse.cs
@@ -86,6 +86,12 @@ public class DiscoveryDocumentResponse : ProtocolResponse
     public IEnumerable<string> BackchannelTokenDeliveryModesSupported => TryGetStringArray(OidcConstants.Discovery.BackchannelTokenDeliveryModesSupported);
     public bool? BackchannelUserCodeParameterSupported => TryGetBoolean(OidcConstants.Discovery.BackchannelUserCodeParameterSupported);
     public bool? RequirePushedAuthorizationRequests => TryGetBoolean(OidcConstants.Discovery.RequirePushedAuthorizationRequests);
+    public IEnumerable<string> IntrospectionSigningAlgorithmsSupported =>
+        TryGetStringArray(OidcConstants.Discovery.IntrospectionSigningAlgorithmsSupported);
+    public IEnumerable<string> IntrospectionEncryptionAlgorithmsSupported =>
+        TryGetStringArray(OidcConstants.Discovery.IntrospectionEncryptionAlgorithmsSupported);
+    public IEnumerable<string> IntrospectionEncryptionEncValuesSupported =>
+        TryGetStringArray(OidcConstants.Discovery.IntrospectionEncryptionEncValuesSupported);
 
     // generic
     public JsonElement? TryGetValue(string name) => Json?.TryGetValue(name);

--- a/identity-model/src/IdentityModel/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -279,6 +279,15 @@ public class DynamicClientRegistrationDocument
     [JsonExtensionData]
     public IDictionary<string, JsonElement>? Extensions { get; set; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
 
+    [JsonPropertyName(OidcConstants.ClientMetadata.IntrospectionSignedResponseAlgorithm)]
+    public string? IntrospectionSignedResponseAlgorithm { get; set; }
+
+    [JsonPropertyName(OidcConstants.ClientMetadata.IntrospectionEncryptedResponseAlgorithm)]
+    public string? IntrospectionEncryptedResponseAlgorithm { get; set; }
+
+    [JsonPropertyName(OidcConstants.ClientMetadata.IntrospectionEncryptedResponseEncryption)]
+    public string? IntrospectionEncryptedResponseEncryption { get; set; }
+
     // Don't serialize empty arrays
     public bool ShouldSerializeRequestUris() => RequestUris.Any();
 

--- a/identity-model/src/IdentityModel/JwtClaimTypes.cs
+++ b/identity-model/src/IdentityModel/JwtClaimTypes.cs
@@ -220,6 +220,11 @@ public static class JwtClaimTypes
         /// DPoP proof token
         /// </summary>
         public const string DPoPProofToken = "dpop+jwt";
+
+        /// <summary>
+        /// Token introspection JWT response
+        /// </summary>
+        public const string IntrospectionJwtResponse = "token-introspection+jwt";
     }
 
     /// <summary>

--- a/identity-model/src/IdentityModel/OidcConstants.cs
+++ b/identity-model/src/IdentityModel/OidcConstants.cs
@@ -273,6 +273,9 @@ public static class OidcConstants
         public const string RequestObjectEncryptionEncryption = "request_object_encryption_enc";
         public const string RequireSignedRequestObject = "require_signed_request_object";
         public const string AlwaysUseDPoPBoundAccessTokens = "dpop_bound_access_tokens";
+        public const string IntrospectionSignedResponseAlgorithm = "introspection_signed_response_alg";
+        public const string IntrospectionEncryptedResponseAlgorithm = "introspection_encrypted_response_alg";
+        public const string IntrospectionEncryptedResponseEncryption = "introspection_encrypted_response_enc";
     }
 
     public static class TokenTypes
@@ -495,6 +498,9 @@ public static class OidcConstants
         public const string TlsClientCertificateBoundAccessTokens = "tls_client_certificate_bound_access_tokens";
         public const string AuthorizationResponseIssParameterSupported = "authorization_response_iss_parameter_supported";
         public const string PromptValuesSupported = "prompt_values_supported";
+        public const string IntrospectionSigningAlgorithmsSupported = "introspection_signing_alg_values_supported";
+        public const string IntrospectionEncryptionAlgorithmsSupported = "introspection_encryption_alg_values_supported";
+        public const string IntrospectionEncryptionEncValuesSupported = "introspection_encryption_enc_values_supported";
 
         // CIBA
         public const string BackchannelTokenDeliveryModesSupported = "backchannel_token_delivery_modes_supported";

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -114,6 +114,7 @@
             public const string AccessToken = "at+jwt";
             public const string AuthorizationRequest = "oauth-authz-req+jwt";
             public const string DPoPProofToken = "dpop+jwt";
+            public const string IntrospectionJwtResponse = "token-introspection+jwt";
         }
     }
     public static class OidcConstants
@@ -302,6 +303,9 @@
             public const string IdentityTokenEncryptedResponseEncryption = "id_token_encrypted_response_enc";
             public const string IdentityTokenSignedResponseAlgorithm = "id_token_signed_response_alg";
             public const string InitiateLoginUri = "initiate_login_uri";
+            public const string IntrospectionEncryptedResponseAlgorithm = "introspection_encrypted_response_alg";
+            public const string IntrospectionEncryptedResponseEncryption = "introspection_encrypted_response_enc";
+            public const string IntrospectionSignedResponseAlgorithm = "introspection_signed_response_alg";
             public const string Jwks = "jwks";
             public const string JwksUri = "jwks_uri";
             public const string LogoUri = "logo_uri";
@@ -370,7 +374,10 @@
             public const string IdTokenEncryptionAlgorithmsSupported = "id_token_encryption_alg_values_supported";
             public const string IdTokenEncryptionEncValuesSupported = "id_token_encryption_enc_values_supported";
             public const string IdTokenSigningAlgorithmsSupported = "id_token_signing_alg_values_supported";
+            public const string IntrospectionEncryptionAlgorithmsSupported = "introspection_encryption_alg_values_supported";
+            public const string IntrospectionEncryptionEncValuesSupported = "introspection_encryption_enc_values_supported";
             public const string IntrospectionEndpoint = "introspection_endpoint";
+            public const string IntrospectionSigningAlgorithmsSupported = "introspection_signing_alg_values_supported";
             public const string Issuer = "issuer";
             public const string JwksUri = "jwks_uri";
             public const string MtlsEndpointAliases = "mtls_endpoint_aliases";
@@ -808,7 +815,10 @@ namespace Duende.IdentityModel.Client
         public bool? FrontChannelLogoutSessionSupported { get; }
         public bool? FrontChannelLogoutSupported { get; }
         public System.Collections.Generic.IEnumerable<string> GrantTypesSupported { get; }
+        public System.Collections.Generic.IEnumerable<string> IntrospectionEncryptionAlgorithmsSupported { get; }
+        public System.Collections.Generic.IEnumerable<string> IntrospectionEncryptionEncValuesSupported { get; }
         public string? IntrospectionEndpoint { get; }
+        public System.Collections.Generic.IEnumerable<string> IntrospectionSigningAlgorithmsSupported { get; }
         public string? Issuer { get; }
         public string? JwksUri { get; }
         public Duende.IdentityModel.Jwk.JsonWebKeySet? KeySet { get; set; }
@@ -893,6 +903,12 @@ namespace Duende.IdentityModel.Client
         public string? IdentityTokenSignedResponseAlgorithm { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("initiate_login_uri")]
         public System.Uri? InitiateLoginUri { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("introspection_encrypted_response_alg")]
+        public string? IntrospectionEncryptedResponseAlgorithm { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("introspection_encrypted_response_enc")]
+        public string? IntrospectionEncryptedResponseEncryption { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("introspection_signed_response_alg")]
+        public string? IntrospectionSignedResponseAlgorithm { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("jwks")]
         public Duende.IdentityModel.Jwk.JsonWebKeySet? Jwks { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("jwks_uri")]


### PR DESCRIPTION
**What issue does this PR address?**

- [x] Adds the new client parameters as constants to `OidcConstants.ClientMetadata`
- [x] Adds the new clients parameters as properties of `DynamicClientRegistrationDocument`
- [x] Adds the new AS parameters as constants to `OidcConstants.Discovery`
- [x] Adds the new AS parameters as properties of `DiscoveryDocumentResponse`
- [x] Adds the new `typ` to `JwtClaimTypes.JwtTypes`

