### PR TITLE
Add trace source for requesting access token

### DIFF
--- a/access-token-management/perf/Perf.DevServer.ServiceDefaults/Extensions.cs
+++ b/access-token-management/perf/Perf.DevServer.ServiceDefaults/Extensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Runtime.CompilerServices;
+using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OTel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -70,7 +71,8 @@ public static class Extensions
                     .AddAspNetCoreInstrumentation()
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
-                    .AddHttpClientInstrumentation();
+                    .AddHttpClientInstrumentation()
+                    .AddSource(ActivitySourceNames.Main);
             });
 
         builder.AddOpenTelemetryExporters();

--- a/access-token-management/perf/Perf.TokenEndpoint/Program.cs
+++ b/access-token-management/perf/Perf.TokenEndpoint/Program.cs
@@ -30,6 +30,7 @@ builder.Services.AddAuthentication("token")
 
 var services = builder.Services;
 services.AddDistributedMemoryCache();
+services.AddHttpClient().AddHttpClient("c1").AddHttpMessageHandler<ChaosMonkeyHandler>();
 services.AddClientCredentialsTokenManagement(opt => opt.CacheLifetimeBuffer = 0)
     .AddClient("c1", opt =>
     {
@@ -86,4 +87,20 @@ app.Run();
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}
+
+public class ChaosMonkeyHandler : DelegatingHandler
+{
+    private static readonly Random _random = new Random();
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // 10% chance to return unauthorized
+        if (_random.Next(0, 100) < 10)
+        {
+            return new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
 }

--- a/access-token-management/perf/Perf.TokenEndpoint/Program.cs
+++ b/access-token-management/perf/Perf.TokenEndpoint/Program.cs
@@ -26,17 +26,21 @@ builder.Services.AddAuthentication("token")
             NameClaimType = "name",
             RoleClaimType = "role"
         };
+        
     });
 
 var services = builder.Services;
+services.AddTransient<ChaosMonkeyHandler>();
 services.AddDistributedMemoryCache();
 services.AddHttpClient().AddHttpClient("c1").AddHttpMessageHandler<ChaosMonkeyHandler>();
+services.AddClientCredentialsHttpClient("t2", "c1");
 services.AddClientCredentialsTokenManagement(opt => opt.CacheLifetimeBuffer = 0)
     .AddClient("c1", opt =>
     {
         opt.TokenEndpoint = new Uri(Services.IdentityServer.ActualUri(), "/connect/token").ToString();
         opt.ClientId = "tokenendpoint";
         opt.ClientSecret = "secret";
+        opt.HttpClientName = "c1";
     })
     .UsePreviewHybridCache();
 
@@ -77,6 +81,15 @@ app.MapGet("/weatherforecast", () =>
 })
 .WithName("GetWeatherForecast");
 
+app.MapGet("/client", async (HttpContext c, IHttpClientFactory factory, CancellationToken ct) =>
+{
+    var client = factory.CreateClient("t2");
+    var response = await client.GetAsync($"https://{c.Request.Host}/ok");
+    return await response.Content.ReadAsStringAsync();
+});
+
+app.MapGet("/ok", () => "ok");
+
 app.MapGet("/token", async (IClientCredentialsTokenManagementService svc, CancellationToken ct) =>
 {
     return await svc.GetAccessTokenAsync("c1");
@@ -96,7 +109,7 @@ public class ChaosMonkeyHandler : DelegatingHandler
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         // 10% chance to return unauthorized
-        if (_random.Next(0, 100) < 10)
+        if (_random.Next(0, 2) == 1)
         {
             return new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
         }

--- a/access-token-management/perf/Perf.TokenEndpoint/Program.cs
+++ b/access-token-management/perf/Perf.TokenEndpoint/Program.cs
@@ -109,7 +109,7 @@ public class ChaosMonkeyHandler : DelegatingHandler
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         // 10% chance to return unauthorized
-        if (_random.Next(0, 2) == 1)
+        if (_random.Next(0, 10) == 0)
         {
             return new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
         }

--- a/access-token-management/perf/Perf.TokenEndpoint/Program.cs
+++ b/access-token-management/perf/Perf.TokenEndpoint/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddAuthentication("token")
             NameClaimType = "name",
             RoleClaimType = "role"
         };
-        
+
     });
 
 var services = builder.Services;

--- a/access-token-management/src/AccessTokenManagement/AccessTokenHandler.cs
+++ b/access-token-management/src/AccessTokenManagement/AccessTokenHandler.cs
@@ -98,7 +98,13 @@ public abstract class AccessTokenHandler(
         CancellationToken cancellationToken,
         string? dpopNonce = null)
     {
-        var token = await GetAccessTokenAsync(forceRenewal, cancellationToken).ConfigureAwait(false);
+        ClientCredentialsToken token;
+
+        // ReSharper disable once ExplicitCallerInfoArgument
+        using (ActivitySources.Main.StartActivity(ActivityNames.AcquiringToken))
+        {
+            token = await GetAccessTokenAsync(forceRenewal, cancellationToken).ConfigureAwait(false);
+        }
 
         if (string.IsNullOrWhiteSpace(token.AccessToken))
         {

--- a/access-token-management/src/AccessTokenManagement/ActivitySources.cs
+++ b/access-token-management/src/AccessTokenManagement/ActivitySources.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace Duende.AccessTokenManagement;
 internal static class ActivitySources
 {
-    
+
     internal static ActivitySource Main = new ActivitySource(ActivitySourceNames.Main);
 }
 

--- a/access-token-management/src/AccessTokenManagement/ActivitySources.cs
+++ b/access-token-management/src/AccessTokenManagement/ActivitySources.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Duende.AccessTokenManagement;
+internal static class ActivitySources
+{
+    
+    internal static ActivitySource Main = new ActivitySource(ActivitySourceNames.Main);
+}
+
+public static class ActivitySourceNames
+{
+    public const string Main = "Duende.AccessTokenManagement";
+}
+
+internal static class ActivityNames
+{
+    public const string AcquiringToken = "Duende.AccessTokenManagement.AcquiringToken";
+}

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementOptions.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementOptions.cs
@@ -13,6 +13,9 @@ public class ClientCredentialsTokenManagementOptions
     /// </summary>
     public string CacheKeyPrefix { get; set; } = "Duende.AccessTokenManagement.Cache::";
 
+    /// <summary>
+    /// Prefix used for the nonce store key
+    /// </summary>
     public string NonceStoreKeyPrefix { get; set; } = "Duende.AccessTokenManagement.DPoPNonceStore::";
 
     /// <summary>

--- a/access-token-management/src/AccessTokenManagement/HybridCacheExtMethods.cs
+++ b/access-token-management/src/AccessTokenManagement/HybridCacheExtMethods.cs
@@ -11,7 +11,7 @@ namespace Duende.AccessTokenManagement;
 ///
 /// https://github.com/dotnet/extensions/issues/5688#issuecomment-2692247434
 /// </summary>
-public static class HybridCacheExtMethods
+internal static class HybridCacheExtMethods
 {
     private static readonly HybridCacheEntryOptions GetOnlyEntryOptions = new()
     {
@@ -20,6 +20,14 @@ public static class HybridCacheExtMethods
                 | HybridCacheEntryFlags.DisableUnderlyingData
     };
 
+    /// <summary>
+    /// Using a get-only entry, this method will return the value if it exists in the cache.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="cache"></param>
+    /// <param name="key"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public static async ValueTask<T?> GetOrDefaultAsync<T>(this HybridCache cache, string key, CancellationToken cancellationToken = default)
     {
         return await cache.GetOrCreateAsync<T?>(

--- a/access-token-management/src/AccessTokenManagement/LogMessages.cs
+++ b/access-token-management/src/AccessTokenManagement/LogMessages.cs
@@ -223,6 +223,11 @@ internal static partial class LogMessages
     public static partial void WritingNonceToCache(this ILogger logger, string url, string method, DateTimeOffset expiration);
 
     [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = $"Writing DPoP nonce to Cache for URL: {{{OTelParameters.Url}}}, method: {{{OTelParameters.Method}}}. Expiration: {{{OTelParameters.Expiration}}}")]
+    public static partial void WritingNonceToCache(this ILogger logger, string url, string method, TimeSpan expiration);
+
+    [LoggerMessage(
         Level = LogLevel.Trace,
         Message = $"Cache miss for DPoP nonce for URL: {{{OTelParameters.Url}}}, method: {{{OTelParameters.Method}}}")]
     public static partial void CacheMissForDPoPNonce(this ILogger logger, string url, string method);

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -10,6 +10,10 @@
         protected virtual System.Threading.Tasks.Task<bool> SetDPoPProofTokenAsync(System.Net.Http.HttpRequestMessage request, Duende.AccessTokenManagement.ClientCredentialsToken token, System.Threading.CancellationToken cancellationToken, string? dpopNonce = null) { }
         protected virtual System.Threading.Tasks.Task<Duende.AccessTokenManagement.ClientCredentialsToken> SetTokenAsync(System.Net.Http.HttpRequestMessage request, bool forceRenewal, System.Threading.CancellationToken cancellationToken, string? dpopNonce = null) { }
     }
+    public static class ActivitySourceNames
+    {
+        public const string Main = "Duende.AccessTokenManagement";
+    }
     public class ClientCredentialsClient
     {
         public ClientCredentialsClient() { }

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -198,10 +198,6 @@
         public static Duende.AccessTokenManagement.DuendeAccessTokenSerializationContext Default { get; }
         public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type) { }
     }
-    public static class HybridCacheExtMethods
-    {
-        public static System.Threading.Tasks.ValueTask<T?> GetOrDefaultAsync<T>(this Microsoft.Extensions.Caching.Hybrid.HybridCache cache, string key, System.Threading.CancellationToken cancellationToken = default) { }
-    }
     public interface IClientAssertionService
     {
         System.Threading.Tasks.Task<Duende.IdentityModel.Client.ClientAssertion?> GetClientAssertionAsync(string? clientName = null, Duende.AccessTokenManagement.TokenRequestParameters? parameters = null);


### PR DESCRIPTION
**What issue does this PR address?**

A trace source with a trace is now added to the access token:

![image](https://github.com/user-attachments/assets/0298f2f8-958c-4255-983d-85f9539663d0)





