### PR TITLE
Add PAR endpoint to mtls aliases in discovery

### DIFF
--- a/identity-model/src/IdentityModel/Client/Messages/MtlsEndpointAliases.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/MtlsEndpointAliases.cs
@@ -45,4 +45,12 @@ public class MtlsEndpointAliases
     /// </summary>
     public string? IntrospectionEndpoint =>
         Json?.TryGetString(OidcConstants.Discovery.IntrospectionEndpoint);
+
+
+    /// <summary>
+    /// Gets the pushed authorization endpoint address.
+    /// </summary>
+    public string? PushedAuthorizationRequestEndpoint =>
+        Json?.TryGetString(OidcConstants.Discovery.PushedAuthorizationRequestEndpoint);
+
 }

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DiscoveryExtensionsTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DiscoveryExtensionsTests.cs
@@ -272,6 +272,7 @@ public class DiscoveryExtensionsTests
         disco.MtlsEndpointAliases.RevocationEndpoint.ShouldBe("https://mtls.identityserver.io/connect/revocation");
         disco.MtlsEndpointAliases.IntrospectionEndpoint.ShouldBe("https://mtls.identityserver.io/connect/introspect");
         disco.MtlsEndpointAliases.DeviceAuthorizationEndpoint.ShouldBe("https://mtls.identityserver.io/connect/deviceauthorization");
+        disco.MtlsEndpointAliases.PushedAuthorizationRequestEndpoint.ShouldBe("https://mtls.identityserver.io/connect/par");
     }
 
     [Fact]

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -1079,6 +1079,7 @@ namespace Duende.IdentityModel.Client
         public string? DeviceAuthorizationEndpoint { get; }
         public string? IntrospectionEndpoint { get; }
         public System.Text.Json.JsonElement? Json { get; }
+        public string? PushedAuthorizationRequestEndpoint { get; }
         public string? RevocationEndpoint { get; }
         public string? TokenEndpoint { get; }
     }

--- a/identity-model/test/IdentityModel.Tests/documents/discovery_mtls.json
+++ b/identity-model/test/IdentityModel.Tests/documents/discovery_mtls.json
@@ -24,6 +24,7 @@
     "token_endpoint": "https://mtls.identityserver.io/connect/token",
     "revocation_endpoint": "https://mtls.identityserver.io/connect/revocation",
     "introspection_endpoint": "https://mtls.identityserver.io/connect/introspect",
-    "device_authorization_endpoint": "https://mtls.identityserver.io/connect/deviceauthorization"
+    "device_authorization_endpoint": "https://mtls.identityserver.io/connect/deviceauthorization",
+    "pushed_authorization_request_endpoint": "https://mtls.identityserver.io/connect/par"
   }
 }


### PR DESCRIPTION
This is stacked on top of https://github.com/DuendeSoftware/foss/pull/181.

This PR introduces the `PushedAuthorizationRequestEndpoint` to the `MtlsEndpointAliases` class and updates related tests and discovery document. This ensures proper handling and validation of the pushed authorization request endpoint in MTLS scenarios.

