### PR TITLE
Remove global.json and sdk pinning

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -254,7 +254,7 @@ public static class StepExtensions
     public static void StepSetupDotNet(this Job job)
         => job.Step()
             .Name("Setup .NET")
-            .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["6.0.x", "8.0.x", "9.0.103"]); // v4.1.0
+            .ActionsSetupDotNet("3e891b0cb619bf60e2c25674b222b8940e2c1c25", ["6.0.x", "8.0.x", "9.0.x"]); // v4.1.0
 
     public static Step IfRefMain(this Step step)
         => step.If("github.ref == 'refs/heads/main'");

--- a/.github/workflows/access-token-management-ci.yml
+++ b/.github/workflows/access-token-management-ci.yml
@@ -49,7 +49,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Verify Formatting
       run: |-
         dotnet restore ../

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -47,7 +47,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Git Config
       run: |-
         git config --global user.email "github-bot@duendesoftware.com"
@@ -106,7 +106,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/identity-model-ci.yml
+++ b/.github/workflows/identity-model-ci.yml
@@ -49,7 +49,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Verify Formatting
       run: |-
         dotnet restore ../

--- a/.github/workflows/identity-model-oidc-client-ci.yml
+++ b/.github/workflows/identity-model-oidc-client-ci.yml
@@ -49,7 +49,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Verify Formatting
       run: |-
         dotnet restore ../

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -47,7 +47,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Git Config
       run: |-
         git config --global user.email "github-bot@duendesoftware.com"
@@ -106,7 +106,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -47,7 +47,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Git Config
       run: |-
         git config --global user.email "github-bot@duendesoftware.com"
@@ -104,7 +104,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/ignore-this-ci.yml
+++ b/.github/workflows/ignore-this-ci.yml
@@ -49,7 +49,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Verify Formatting
       run: |-
         dotnet restore ../

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -47,7 +47,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: Git Config
       run: |-
         git config --global user.email "github-bot@duendesoftware.com"
@@ -104,7 +104,7 @@ jobs:
         dotnet-version: |-
           6.0.x
           8.0.x
-          9.0.103
+          9.0.x
     - name: List files
       run: tree
       shell: bash

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.102",
-    "rollForward": "latestPatch",
-    "allowPrerelease": false
-  }
-}


### PR DESCRIPTION
We no longer need to prevent upgrades to the sdk version, because the fix for the dotnet format issue that originally prompted that has been released.