### PR TITLE
Fix broken documentation link

### DIFF
--- a/identity-model/README.md
+++ b/identity-model/README.md
@@ -15,7 +15,7 @@ Duende.IdentityModel targets [.NET Standard 2.0](https://learn.microsoft.com/en-
 making it suitable for .NET and .NET Framework.
 
 For more documentation, please see the  
-[documentation site](https://docs.duendesoftware.com/foss).
+[documentation site](https://docs.duendesoftware.com/identitymodel).
 
 ## Related Packages
 


### PR DESCRIPTION
**What issue does this PR address?**
Fixes a broken link in the Identity Model readme markdown file pointing to a non-existing docs page.

Closes https://github.com/DuendeSoftware/foss/issues/212