### PR TITLE
Make sure hybrid cache allows AOT client credentials tokens 

### DIFF
--- a/access-token-management/samples/Worker/Program.cs
+++ b/access-token-management/samples/Worker/Program.cs
@@ -3,30 +3,26 @@
 
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.DPoP;
 using Microsoft.IdentityModel.Tokens;
-using Serilog;
-using Serilog.Sinks.SystemConsole.Themes;
 
 namespace WorkerService;
 
 public class Program
 {
-    public static void Main(string[] args)
-    {
-        Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Debug()
-            .WriteTo.Console(theme: AnsiConsoleTheme.Code)
-            .CreateLogger();
+    public static void Main(string[] args) =>
+        //Log.Logger = new LoggerConfiguration()
+        //    .MinimumLevel.Debug()
+        //    .WriteTo.Console(theme: AnsiConsoleTheme.Code)
+        //    .CreateLogger();
 
         CreateHostBuilder(args).Build().Run();
-    }
 
     public static IHostBuilder CreateHostBuilder(string[] args)
     {
         var host = Host.CreateDefaultBuilder(args)
-            .UseSerilog()
 
             .ConfigureServices((services) =>
             {
@@ -93,8 +89,10 @@ public class Program
         var key = new RsaSecurityKey(RSA.Create(2048));
         var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
         jwk.Alg = "PS256";
-        var jwkJson = JsonSerializer.Serialize(jwk);
+        var jwkJson = JsonSerializer.Serialize(jwk, WorkerSerializationContext.Default.JsonWebKey);
         return DPoPProofKey.Parse(jwkJson);
     }
 
 }
+[JsonSerializable(typeof(JsonWebKey))]
+internal partial class WorkerSerializationContext : JsonSerializerContext;

--- a/access-token-management/samples/Worker/Program.cs
+++ b/access-token-management/samples/Worker/Program.cs
@@ -13,11 +13,6 @@ namespace WorkerService;
 public class Program
 {
     public static void Main(string[] args) =>
-        //Log.Logger = new LoggerConfiguration()
-        //    .MinimumLevel.Debug()
-        //    .WriteTo.Console(theme: AnsiConsoleTheme.Code)
-        //    .CreateLogger();
-
         CreateHostBuilder(args).Build().Run();
 
     public static IHostBuilder CreateHostBuilder(string[] args)

--- a/access-token-management/samples/Worker/Worker.csproj
+++ b/access-token-management/samples/Worker/Worker.csproj
@@ -2,8 +2,14 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+    <PublishAot>true</PublishAot>
+    <TrimmerSingleWarn>true</TrimmerSingleWarn>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
   </ItemGroup>

--- a/access-token-management/src/AccessTokenManagement/AccessTokenManagement.csproj
+++ b/access-token-management/src/AccessTokenManagement/AccessTokenManagement.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <PackageId>Duende.AccessTokenManagement</PackageId>
@@ -6,7 +6,10 @@
     <RootNamespace>$(PackageId)</RootNamespace>
     <Description>Automatic access token management for OAuth client credential flows</Description>
     <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
     <PackageReadmePath>README.md</PackageReadmePath>
+    <PublishAot>true</PublishAot>
+    <TrimmerSingleWarn>true</TrimmerSingleWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Duende.IdentityModel" />

--- a/access-token-management/src/AccessTokenManagement/Internal/AotTrimCompatibleClientCredentialsTokenSerializer.cs
+++ b/access-token-management/src/AccessTokenManagement/Internal/AotTrimCompatibleClientCredentialsTokenSerializer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Buffers;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace Duende.AccessTokenManagement.Internal;
+
+/// <summary>
+/// This class makes sure the ClientCredentialsToken is serialized in an AOT compatible way. 
+/// </summary>
+internal class AotTrimCompatibleClientCredentialsTokenSerializer : IHybridCacheSerializer<ClientCredentialsToken>
+{
+    public ClientCredentialsToken Deserialize(ReadOnlySequence<byte> source)
+    {
+        var reader = new Utf8JsonReader(source);
+
+        return JsonSerializer.Deserialize(ref reader, DuendeAccessTokenSerializationContext.Default.ClientCredentialsToken)!;
+    }
+
+    public void Serialize(ClientCredentialsToken value, IBufferWriter<byte> target)
+    {
+        using var writer = new Utf8JsonWriter(target);
+
+        JsonSerializer.Serialize<ClientCredentialsToken>(writer, value, DuendeAccessTokenSerializationContext.Default.ClientCredentialsToken);
+    }
+}

--- a/access-token-management/src/AccessTokenManagement/Internal/DuendeAccessTokenSerializationContext.cs
+++ b/access-token-management/src/AccessTokenManagement/Internal/DuendeAccessTokenSerializationContext.cs
@@ -12,4 +12,5 @@ namespace Duende.AccessTokenManagement.Internal;
 [JsonSerializable(typeof(Uri))]
 [JsonSerializable(typeof(long))]
 [JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(ClientCredentialsToken))]
 internal partial class DuendeAccessTokenSerializationContext : JsonSerializerContext;

--- a/access-token-management/src/AccessTokenManagement/ServiceCollectionExtensions.cs
+++ b/access-token-management/src/AccessTokenManagement/ServiceCollectionExtensions.cs
@@ -42,6 +42,9 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<IClientCredentialsTokenManager, ClientCredentialsTokenManager>();
         services.AddHybridCache();
 
+        // Add a default serializer for ClientCredentialsToken
+        services.TryAddSingleton<IHybridCacheSerializer<ClientCredentialsToken>, AotTrimCompatibleClientCredentialsTokenSerializer>();
+
         // By default, resolve the default hybrid cache for the DefaultClientCredentialsTokenManager
         // without key. If desired, a consumers can register the distributed cache with a key
         services.TryAddKeyedSingleton<HybridCache>(ServiceProviderKeys.ClientCredentialsTokenCache, (sp, _) => sp.GetRequiredService<HybridCache>());


### PR DESCRIPTION
**What issue does this PR address?**

By default, the hybrid cache serializer doesn't allow AOT, because it doesn't know the types it's going to serialize upfront. 

This PR makes sure that at least by default, we register a hybrid cache serializer that IS AOT compatible. 

Note, this PR cannot prevent that this warning is raised:

```
 Worker net9.0 succeeded with 4 warning(s) (11.8s) → bin\Release\net9.0\win-x64\publish\
    ILC : Trim analysis warning IL2026: 
      Microsoft.Extensions.Caching.Hybrid.Internal.DefaultJsonSerializerFactory.DefaultJsonSerializerFactory(IServiceProvider): 
      Using member 'System.Text.Json.JsonSerializerOptions.Default.get' which has 'RequiresUnreferencedCodeAttribute' can 
      break functionality when trimming application code. JSON serialization and deserialization might require types that 
      cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the 
      required types are preserved.
```
This is because, technically, hybridcache still allows you to add your own types that are not AOT compatible. I did publish the worker sample using AOT, and verified that it's working. 

I'll add a comment in the docs about this as well. 