### PR TITLE
Validate version input

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -138,6 +138,10 @@ void GenerateReleaseWorkflow(Component component)
         .ActionsCheckout();
 
     tagJob.Step()
+        .Name("Validate Version Input")
+        .Run($@"echo '{contexts.Event.Input.Version}' | grep -P '^\d+\.\d+\.\d+(-preview\.\d+|-rc\.\d+)?$'");
+
+    tagJob.Step()
         .Name("Checkout target branch")
         .If("github.event.inputs.branch != 'main'")
         .Run("git checkout ${{ github.event.inputs.branch }}");

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        description: 'Version in format X.Y.Z, X.Y.Z-preview.N, or X.Y.Z-rc.N '
         type: string
         required: true
         default: '0.0.0'
@@ -38,6 +38,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Validate Version Input
+      run: echo '${{ github.event.inputs.version }}' | grep -P '^\d+\.\d+\.\d+(-preview\.\d+|-rc\.\d+)?$'
     - name: Checkout target branch
       if: github.event.inputs.branch != 'main'
       run: git checkout ${{ github.event.inputs.branch }}

--- a/.github/workflows/identity-model-introspection-release.yml
+++ b/.github/workflows/identity-model-introspection-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        description: 'Version in format X.Y.Z, X.Y.Z-preview.N, or X.Y.Z-rc.N '
         type: string
         required: true
         default: '0.0.0'
@@ -38,6 +38,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Validate Version Input
+      run: echo '${{ github.event.inputs.version }}' | grep -P '^\d+\.\d+\.\d+(-preview\.\d+|-rc\.\d+)?$'
     - name: Checkout target branch
       if: github.event.inputs.branch != 'main'
       run: git checkout ${{ github.event.inputs.branch }}

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        description: 'Version in format X.Y.Z, X.Y.Z-preview.N, or X.Y.Z-rc.N '
         type: string
         required: true
         default: '0.0.0'
@@ -38,6 +38,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Validate Version Input
+      run: echo '${{ github.event.inputs.version }}' | grep -P '^\d+\.\d+\.\d+(-preview\.\d+|-rc\.\d+)?$'
     - name: Checkout target branch
       if: github.event.inputs.branch != 'main'
       run: git checkout ${{ github.event.inputs.branch }}

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        description: 'Version in format X.Y.Z, X.Y.Z-preview.N, or X.Y.Z-rc.N '
         type: string
         required: true
         default: '0.0.0'
@@ -38,6 +38,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Validate Version Input
+      run: echo '${{ github.event.inputs.version }}' | grep -P '^\d+\.\d+\.\d+(-preview\.\d+|-rc\.\d+)?$'
     - name: Checkout target branch
       if: github.event.inputs.branch != 'main'
       run: git checkout ${{ github.event.inputs.branch }}

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version in format X.Y.Z or X.Y.Z-preview.'
+        description: 'Version in format X.Y.Z, X.Y.Z-preview.N, or X.Y.Z-rc.N '
         type: string
         required: true
         default: '0.0.0'
@@ -38,6 +38,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Validate Version Input
+      run: echo '${{ github.event.inputs.version }}' | grep -P '^\d+\.\d+\.\d+(-preview\.\d+|-rc\.\d+)?$'
     - name: Checkout target branch
       if: github.event.inputs.branch != 'main'
       run: git checkout ${{ github.event.inputs.branch }}


### PR DESCRIPTION
Validates that version input to release builds follows the expected format. This should prevent tags with duplicated prefixes, and make sure that we are consistent in how we tag previews and RCs.

