### PR TITLE
Allow client assertions for ATM OpenIdConnect

### DIFF
--- a/access-token-management/samples/WebJarJwt/Startup.cs
+++ b/access-token-management/samples/WebJarJwt/Startup.cs
@@ -3,6 +3,7 @@
 
 using Duende.AccessTokenManagement;
 using Duende.AccessTokenManagement.OpenIdConnect;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using Serilog.Events;
@@ -53,6 +54,9 @@ public static class Startup
                     NameClaimType = "name",
                     RoleClaimType = "role"
                 };
+
+                // Disable PAR because it is incompatible with currently wired up OidcEvents
+                options.PushedAuthorizationBehavior = PushedAuthorizationBehavior.Disable;
             });
 
         builder.Services.AddOpenIdConnectAccessTokenManagement();

--- a/access-token-management/samples/WebJarJwt/Views/Home/Secure.cshtml
+++ b/access-token-management/samples/WebJarJwt/Views/Home/Secure.cshtml
@@ -16,7 +16,7 @@
 |
 <a href="./CallApiAsClientFactory">HTTP client factory</a>
 |
-<a href="./CallApiAsClientFactoryTypes">HTTP client factory (typed)</a>
+<a href="./CallApiAsClientFactoryTyped">HTTP client factory (typed)</a>
 
 
 <h2>Claims</h2>

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectConfigurationService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectConfigurationService.cs
@@ -60,7 +60,7 @@ internal class OpenIdConnectConfigurationService(
             TokenEndpoint = new Uri(configuration.TokenEndpoint),
             RevocationEndpoint = configuration.RevocationEndpoint == null ? null : new Uri(configuration.RevocationEndpoint),
             ClientId = ClientId.Parse(options.ClientId ?? throw new InvalidOperationException("ClientId is null")),
-            ClientSecret = ClientSecret.Parse(options.ClientSecret ?? throw new InvalidOperationException("ClientSecret is null")),
+            ClientSecret = options.ClientSecret == null ? null : ClientSecret.Parse(options.ClientSecret),
             HttpClient = options.Backchannel,
         };
     }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectClientConfiguration.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/OpenIdConnectClientConfiguration.cs
@@ -33,7 +33,7 @@ public sealed class OpenIdConnectClientConfiguration
     /// <summary>
     /// The client secret
     /// </summary>
-    public required ClientSecret ClientSecret { get; set; }
+    public ClientSecret? ClientSecret { get; set; }
 
     /// <summary>
     /// The HTTP client associated with the OIDC handler (if based on scheme configuration)

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
@@ -18,6 +18,7 @@ namespace Duende.AccessTokenManagement.Tests;
 public class AppHost : GenericHost
 {
     public string ClientId;
+    public string? ClientSecret;
 
     private readonly IdentityServerHost _identityServerHost;
     private readonly ApiHost _apiHost;
@@ -35,6 +36,7 @@ public class AppHost : GenericHost
         _identityServerHost = identityServerHost;
         _apiHost = apiHost;
         ClientId = clientId;
+        ClientSecret = "secret";
         _configureUserTokenManagementOptions = configureUserTokenManagementOptions;
         OnConfigureServices += ConfigureServices;
         OnConfigure += Configure;
@@ -68,7 +70,7 @@ public class AppHost : GenericHost
                 options.Authority = _identityServerHost.Url();
 
                 options.ClientId = ClientId;
-                options.ClientSecret = "secret";
+                options.ClientSecret = ClientSecret;
                 options.ResponseType = "code";
                 options.ResponseMode = "query";
 

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
@@ -50,8 +50,7 @@
         public OpenIdConnectClientConfiguration() { }
         [System.Runtime.CompilerServices.RequiredMember]
         public Duende.AccessTokenManagement.ClientId ClientId { get; set; }
-        [System.Runtime.CompilerServices.RequiredMember]
-        public Duende.AccessTokenManagement.ClientSecret ClientSecret { get; set; }
+        public Duende.AccessTokenManagement.ClientSecret? ClientSecret { get; set; }
         public System.Net.Http.HttpClient? HttpClient { get; set; }
         public System.Uri? RevocationEndpoint { get; set; }
         public Duende.AccessTokenManagement.Scheme Scheme { get; set; }


### PR DESCRIPTION
**What issue does this PR address?**
* Addresses a couple issues which were keeping the WebJarJwt sample from working end-to-end
* Allows a null client secret in client configuration for ATM OpenIdConnect package to allow for using client assertions

