### PR TITLE
Add Missing JsonConverter Attributes

### DIFF
--- a/access-token-management/src/AccessTokenManagement/IdentityToken.cs
+++ b/access-token-management/src/AccessTokenManagement/IdentityToken.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Duende.AccessTokenManagement.Internal;
 
 namespace Duende.AccessTokenManagement;
 
+[JsonConverter(typeof(StringValueJsonConverter<IdentityToken>))]
 public readonly record struct IdentityToken : IStronglyTypedValue<IdentityToken>
 {
     public const int MaxLength = 32 * 1024;
@@ -17,7 +19,7 @@ public readonly record struct IdentityToken : IStronglyTypedValue<IdentityToken>
     ];
 
     /// <summary>
-    /// You can't directly create this type. 
+    /// You can't directly create this type.
     /// </summary>
     /// <exception cref="InvalidOperationException"></exception>
     public IdentityToken() => throw new InvalidOperationException("Can't create null value");
@@ -49,7 +51,7 @@ public readonly record struct IdentityToken : IStronglyTypedValue<IdentityToken>
     /// <summary>
     /// Parses a value to a <see cref="IdentityToken"/>. This will return null if the provided string
     /// is null or whitespace. This is a convenience method for when you want to parse a value that may
-    /// contain null or whitespace strings. 
+    /// contain null or whitespace strings.
     /// </summary>
     public static IdentityToken? ParseOrDefault(string? value) => StringParsers<IdentityToken>.ParseOrDefault(value);
 }

--- a/access-token-management/src/AccessTokenManagement/RefreshToken.cs
+++ b/access-token-management/src/AccessTokenManagement/RefreshToken.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Duende.AccessTokenManagement.Internal;
 
 namespace Duende.AccessTokenManagement;
 
+[JsonConverter(typeof(StringValueJsonConverter<RefreshToken>))]
 public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
 {
     public const int MaxLength = 4 * 1024;
@@ -17,7 +19,7 @@ public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
     ];
 
     /// <summary>
-    /// You can't directly create this type. 
+    /// You can't directly create this type.
     /// </summary>
     /// <exception cref="InvalidOperationException"></exception>
     public RefreshToken() => throw new InvalidOperationException("Can't create null value");

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -166,6 +166,7 @@
         System.Threading.Tasks.Task DeleteAccessTokenAsync(Duende.AccessTokenManagement.ClientCredentialsClientName clientName, Duende.AccessTokenManagement.TokenRequestParameters? parameters = null, System.Threading.CancellationToken ct = default);
         System.Threading.Tasks.Task<Duende.AccessTokenManagement.TokenResult<Duende.AccessTokenManagement.ClientCredentialsToken>> GetAccessTokenAsync(Duende.AccessTokenManagement.ClientCredentialsClientName clientName, Duende.AccessTokenManagement.TokenRequestParameters? parameters = null, System.Threading.CancellationToken ct = default);
     }
+    [System.Text.Json.Serialization.JsonConverter(typeof(Duende.AccessTokenManagement.Internal.StringValueJsonConverter<Duende.AccessTokenManagement.IdentityToken>))]
     public readonly struct IdentityToken : System.IEquatable<Duende.AccessTokenManagement.IdentityToken>
     {
         public const int MaxLength = 32768;
@@ -176,6 +177,7 @@
         public static bool TryParse(string value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.AccessTokenManagement.IdentityToken? parsed, out string[] errors) { }
         public static string op_Implicit(Duende.AccessTokenManagement.IdentityToken value) { }
     }
+    [System.Text.Json.Serialization.JsonConverter(typeof(Duende.AccessTokenManagement.Internal.StringValueJsonConverter<Duende.AccessTokenManagement.RefreshToken>))]
     public readonly struct RefreshToken : System.IEquatable<Duende.AccessTokenManagement.RefreshToken>
     {
         public const int MaxLength = 4096;


### PR DESCRIPTION
**What issue does this PR address?**
Added JsonConverter attribute on types used in UserToken properties which did not have it to allow deserializing JSON into a UserToken object.

