### PR TITLE
Fix some formatting that is causing .NET 10 PR to fail

### DIFF
--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/FakeTimeProvider.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/FakeTimeProvider.cs
@@ -4,8 +4,10 @@
 using Microsoft.Extensions.Internal;
 
 namespace Duende.AccessTokenManagement.Framework;
+
 internal class FakeTimeProvider(Func<DateTimeOffset> utcNow) : TimeProvider, ISystemClock
 {
     public override DateTimeOffset GetUtcNow() => utcNow();
+
     public DateTimeOffset UtcNow => utcNow();
 }

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/TestLoggerProvider.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/TestLoggerProvider.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Duende.AccessTokenManagement.Framework;
+
 public class TestLoggerProvider(WriteTestOutput writeOutput, string name) : ILoggerProvider
 {
     private readonly Stopwatch _watch = Stopwatch.StartNew();

--- a/identity-model/src/IdentityModel/Validation/ITokenIntrospectionJwtResponseValidator.cs
+++ b/identity-model/src/IdentityModel/Validation/ITokenIntrospectionJwtResponseValidator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 namespace Duende.IdentityModel.Validation;
+
 public interface ITokenIntrospectionJwtResponseValidator
 {
     /// <summary>


### PR DESCRIPTION
.NET 10 analysers have expanded, this PR fixes them seperately.

```
Run dotnet format ../ --verify-no-changes --no-restore
/home/runner/work/foss/foss/access-token-management/test/AccessTokenManagement.Tests/Framework/FakeTimeProvider.cs(7,1): error WHITESPACE: Fix whitespace formatting. Insert '\n'. [/home/runner/work/foss/foss/access-token-management/test/AccessTokenManagement.Tests/AccessTokenManagement.Tests.csproj]
/home/runner/work/foss/foss/access-token-management/test/AccessTokenManagement.Tests/Framework/TestLoggerProvider.cs(8,1): error WHITESPACE: Fix whitespace formatting. Insert '\n'. [/home/runner/work/foss/foss/access-token-management/test/AccessTokenManagement.Tests/AccessTokenManagement.Tests.csproj]
/home/runner/work/foss/foss/identity-model/src/IdentityModel/Validation/ITokenIntrospectionJwtResponseValidator.cs(5,1): error WHITESPACE: Fix whitespace formatting. Insert '\n'. [/home/runner/work/foss/foss/identity-model/src/IdentityModel/IdentityModel.csproj]
```
