### PR TITLE
CI/CD: Separate restore from format

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -86,6 +86,8 @@ void GenerateCiWorkflow(Component component)
 
     job.StepSetupDotNet();
 
+    job.StepRestore();
+
     job.StepVerifyFormatting();
 
     foreach (var testProject in component.Tests)
@@ -364,10 +366,12 @@ public static class StepExtensions
     public static Step StepVerifyFormatting(this Job job)
         => job.Step()
             .Name("Verify Formatting")
-            .Run("""
-                 dotnet restore ../
-                 dotnet format ../ --verify-no-changes --no-restore
-                 """);
+            .Run("dotnet format ../ --verify-no-changes --no-restore");
+
+    public static Step StepRestore(this Job job)
+        => job.Step()
+            .Name("Restore")
+            .Run("dotnet restore ../");
 
     public static void StepUploadArtifacts(this Job job, string componentName, bool uploadAlways = false)
     {

--- a/.github/workflows/access-token-management-ci.yml
+++ b/.github/workflows/access-token-management-ci.yml
@@ -50,10 +50,10 @@ jobs:
           6.0.x
           8.0.x
           9.0.203
+    - name: Restore
+      run: dotnet restore ../
     - name: Verify Formatting
-      run: |-
-        dotnet restore ../
-        dotnet format ../ --verify-no-changes --no-restore
+      run: dotnet format ../ --verify-no-changes --no-restore
     - name: Test - AccessTokenManagement.Tests
       run: dotnet test -c Release test/AccessTokenManagement.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=AccessTokenManagement.Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report

--- a/.github/workflows/identity-model-ci.yml
+++ b/.github/workflows/identity-model-ci.yml
@@ -50,10 +50,10 @@ jobs:
           6.0.x
           8.0.x
           9.0.203
+    - name: Restore
+      run: dotnet restore ../
     - name: Verify Formatting
-      run: |-
-        dotnet restore ../
-        dotnet format ../ --verify-no-changes --no-restore
+      run: dotnet format ../ --verify-no-changes --no-restore
     - name: Test - IdentityModel.Tests
       run: dotnet test -c Release test/IdentityModel.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=IdentityModel.Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report

--- a/.github/workflows/identity-model-oidc-client-ci.yml
+++ b/.github/workflows/identity-model-oidc-client-ci.yml
@@ -50,10 +50,10 @@ jobs:
           6.0.x
           8.0.x
           9.0.203
+    - name: Restore
+      run: dotnet restore ../
     - name: Verify Formatting
-      run: |-
-        dotnet restore ../
-        dotnet format ../ --verify-no-changes --no-restore
+      run: dotnet format ../ --verify-no-changes --no-restore
     - name: Test - IdentityModel.OidcClient.Tests
       run: dotnet test -c Release test/IdentityModel.OidcClient.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=IdentityModel.OidcClient.Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report

--- a/.github/workflows/ignore-this-ci.yml
+++ b/.github/workflows/ignore-this-ci.yml
@@ -50,10 +50,10 @@ jobs:
           6.0.x
           8.0.x
           9.0.203
+    - name: Restore
+      run: dotnet restore ../
     - name: Verify Formatting
-      run: |-
-        dotnet restore ../
-        dotnet format ../ --verify-no-changes --no-restore
+      run: dotnet format ../ --verify-no-changes --no-restore
     - name: Test - IgnoreThis.Tests
       run: dotnet test -c Release test/IgnoreThis.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=IgnoreThis.Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report

--- a/.github/workflows/introspection-ci.yml
+++ b/.github/workflows/introspection-ci.yml
@@ -50,10 +50,10 @@ jobs:
           6.0.x
           8.0.x
           9.0.203
+    - name: Restore
+      run: dotnet restore ../
     - name: Verify Formatting
-      run: |-
-        dotnet restore ../
-        dotnet format ../ --verify-no-changes --no-restore
+      run: dotnet format ../ --verify-no-changes --no-restore
     - name: Test - AspNetCore.Authentication.OAuth2Introspection.Tests
       run: dotnet test -c Release test/AspNetCore.Authentication.OAuth2Introspection.Tests --logger "console;verbosity=normal" --logger "trx;LogFileName=AspNetCore.Authentication.OAuth2Introspection.Tests.trx" --collect:"XPlat Code Coverage"
     - name: Test report


### PR DESCRIPTION
Small change to put the dotnet restore and dotnet format into separate steps.


