### PR TITLE
Allow Using HttpClient BaseAddres for Authority in DiscoveryCache

### DIFF
--- a/identity-model/test/IdentityModel.Tests/DiscoveryCacheTests.cs
+++ b/identity-model/test/IdentityModel.Tests/DiscoveryCacheTests.cs
@@ -41,4 +41,26 @@ public class DiscoveryCacheTests
 
         disco.IsError.ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task New_initialization_without_authority_should_work()
+    {
+        var client = new HttpClient(_successHandler) { BaseAddress = new Uri(_authority) };
+        var cache = new DiscoveryCache(() => client);
+
+        var disco = await cache.GetAsync();
+
+        disco.IsError.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task New_initialization_with_no_authority_and_client_func_without_base_address_should_throw()
+    {
+        var client = new HttpClient(_successHandler);
+        var cache = new DiscoveryCache(() => client);
+
+        var exception = await Should.ThrowAsync<InvalidOperationException>(async () => await cache.GetAsync());
+
+        exception.Message.ShouldBe("DiscoveryCache cannot determine the authority. Either pass the authority in the constructor or pass httpClientFunc which returns an instance of HttpClient with a BaseAddress.");
+    }
 }

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -791,6 +791,7 @@ namespace Duende.IdentityModel.Client
     }
     public class DiscoveryCache : Duende.IdentityModel.Client.IDiscoveryCache
     {
+        public DiscoveryCache(System.Func<System.Net.Http.HttpMessageInvoker> httpClientFunc, Duende.IdentityModel.Client.DiscoveryPolicy? policy = null) { }
         public DiscoveryCache(string authority, Duende.IdentityModel.Client.DiscoveryPolicy? policy = null) { }
         public DiscoveryCache(string authority, System.Func<System.Net.Http.HttpMessageInvoker> httpClientFunc, Duende.IdentityModel.Client.DiscoveryPolicy? policy = null) { }
         public System.TimeSpan CacheDuration { get; set; }


### PR DESCRIPTION
**What issue does this PR address?**
Adds a new constructor to DiscoveryCache to allow the use of the BaseAddress from an HttpClient as the authority. This also required making the `_authority` member nullable and adding the conditional to find the appropriate value.
