### PR TITLE
Make DynamicClientRegistrationDocument.Extensions Non Nullable

### DIFF
--- a/identity-model/src/IdentityModel/Client/Messages/DynamicClientRegistrationDocument.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/DynamicClientRegistrationDocument.cs
@@ -115,7 +115,7 @@ public class DynamicClientRegistrationDocument
     /// URL using the https scheme to be used in calculating Pseudonymous Identifiers by the OpenID provider.
     /// </summary>
     /// <remarks>
-    /// The URL references a file with a single JSON array of <c>redirect_uri</c> values. 
+    /// The URL references a file with a single JSON array of <c>redirect_uri</c> values.
     /// </remarks>
     [JsonPropertyName(OidcConstants.ClientMetadata.SectorIdentifierUri)]
     public Uri? SectorIdentifierUri { get; set; }
@@ -277,7 +277,7 @@ public class DynamicClientRegistrationDocument
     /// Custom client metadata fields to include in the serialization.
     /// </summary>
     [JsonExtensionData]
-    public IDictionary<string, JsonElement>? Extensions { get; set; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+    public IDictionary<string, JsonElement> Extensions { get; set; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
 
     [JsonPropertyName(OidcConstants.ClientMetadata.IntrospectionSignedResponseAlgorithm)]
     public string? IntrospectionSignedResponseAlgorithm { get; set; }

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DynamicClientRegistrationTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/DynamicClientRegistrationTests.cs
@@ -166,7 +166,7 @@ public class DynamicClientRegistrationTests
         {
             Address = Endpoint,
             Document = JsonSerializer.Deserialize<DynamicClientRegistrationDocument>(
-                "{\"extension\":\"data\"}")
+                "{\"custom_field\":\"data\"}")
         };
         request.Document.Extensions.ShouldNotBeEmpty();
 
@@ -178,5 +178,32 @@ public class DynamicClientRegistrationTests
 
         // Mostly we just want to make sure that serialization didn't throw
         response.ShouldNotBeNull();
+
+        //ensure the extension made it into the request
+        var requestContent = await handler.Request?.Content?.ReadAsStringAsync()!;
+        var requestContentJson = JsonSerializer.Deserialize<JsonElement>(requestContent);
+        requestContentJson.GetProperty("custom_field").GetString().ShouldBe("data");
+    }
+
+    [Fact]
+    public void Extensions_should_not_be_null_after_deserializing_json_without_custom_client_metadata()
+    {
+        var json = "{}";
+
+        var doc = JsonSerializer.Deserialize<DynamicClientRegistrationDocument>(json);
+
+        doc.Extensions.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Extensions_should_contain_data_after_deserialization()
+    {
+        var json = "{\"custom_field\":\"123\"}";
+
+        var doc = JsonSerializer.Deserialize<DynamicClientRegistrationDocument>(json);
+
+        doc.Extensions.ShouldNotBeEmpty();
+        doc.Extensions.Count.ShouldBe(1);
+        doc.Extensions["custom_field"].GetString().ShouldBe("123");
     }
 }

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -933,7 +933,7 @@ namespace Duende.IdentityModel.Client
         [System.Text.Json.Serialization.JsonPropertyName("default_max_age")]
         public int? DefaultMaxAge { get; set; }
         [System.Text.Json.Serialization.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, System.Text.Json.JsonElement>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, System.Text.Json.JsonElement> Extensions { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("frontchannel_logout_session_required")]
         public bool? FrontChannelLogoutSessionRequired { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("frontchannel_logout_uri")]


### PR DESCRIPTION
**What issue does this PR address?**
Made the Extensions property on DynamicClientRegistrationDocument non-nullable and added additional tests around serialization/de-serializing the property.

