### PR TITLE
Target net 8 and 9 in the interim

### DIFF
--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -68,9 +68,9 @@ jobs:
         git tag -a atm-${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
         git push origin atm-${{ github.event.inputs.version }}
     - name: Pack AccessTokenManagement
-      run: dotnet pack -c Release src/AccessTokenManagement -o artifacts
+      run: dotnet pack -c Release src/AccessTokenManagement -o artifacts '/p:TargetFrameworks="net8.0;net9.0"'
     - name: Pack AccessTokenManagement.OpenIdConnect
-      run: dotnet pack -c Release src/AccessTokenManagement.OpenIdConnect -o artifacts
+      run: dotnet pack -c Release src/AccessTokenManagement.OpenIdConnect -o artifacts '/p:TargetFrameworks="net8.0;net9.0"'
     - name: Tool restore
       run: dotnet tool restore
     - name: Sign packages

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,16 +1,18 @@
 <Project>
   <PropertyGroup>
-    <ExtensionsVersion>10.0.0-rc.1.25451.107</ExtensionsVersion>
 	  <WilsonVersion>[8.0.1,9.0.0)</WilsonVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
     <FrameworkVersion>8.0.1</FrameworkVersion>
+    <ExtensionsVersion>9.0.9</ExtensionsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net9.0'">
     <FrameworkVersion>9.0.0</FrameworkVersion>
+    <ExtensionsVersion>9.0.9</ExtensionsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0'">
     <FrameworkVersion>10.0.0-rc.1.25451.107</FrameworkVersion>
+    <ExtensionsVersion>10.0.0-rc.1.25451.107</ExtensionsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.3.0" />


### PR DESCRIPTION
**What issue does this PR address?**
- In the interim, we will not attempt to produce .NET 10 packages for ATM
- We also dont want to produce ATM packages that references preview packages