### PR TITLE
Introduce IDPoPProofTokenFactory

### DIFF
--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/DefaultDPoPProofTokenFactory.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/DefaultDPoPProofTokenFactory.cs
@@ -12,14 +12,14 @@ namespace Duende.IdentityModel.OidcClient.DPoP;
 /// <summary>
 /// Used to create DPoP proof tokens.
 /// </summary>
-public class DPoPProofTokenFactory
+public class DefaultDPoPProofTokenFactory : IDPoPProofTokenFactory
 {
     private readonly JsonWebKey _jwk;
 
     /// <summary>
     /// Constructor
     /// </summary>
-    public DPoPProofTokenFactory(string proofKey)
+    public DefaultDPoPProofTokenFactory(string proofKey)
     {
         _jwk = new JsonWebKey(proofKey);
 
@@ -79,7 +79,7 @@ public class DPoPProofTokenFactory
 
         if (!string.IsNullOrWhiteSpace(request.AccessToken))
         {
-            // ath: hash of the access token. The value MUST be the result of a base64url encoding 
+            // ath: hash of the access token. The value MUST be the result of a base64url encoding
             // the SHA-256 hash of the ASCII encoding of the associated access token's value.
             using var sha256 = SHA256.Create();
             var hash = sha256.ComputeHash(Encoding.ASCII.GetBytes(request.AccessToken));

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/IDPoPProofTokenFactory.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/IDPoPProofTokenFactory.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Duende.IdentityModel.OidcClient.DPoP;
+
+public interface IDPoPProofTokenFactory
+{
+    DPoPProof CreateProofToken(DPoPProofRequest request);
+}

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/OidcClientExtensions.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/OidcClientExtensions.cs
@@ -20,8 +20,27 @@ public static class OidcClientExtensions
         HttpMessageHandler? tokenEndpointInnerHandler = null,
         HttpMessageHandler? apiInnerHandler = null)
     {
-        var tokenDpopHandler = new ProofTokenMessageHandler(proofKey, tokenEndpointInnerHandler ?? new HttpClientHandler());
-        var apiDpopHandler = new ProofTokenMessageHandler(proofKey, apiInnerHandler ?? new HttpClientHandler());
+        var tokenDpopHandler = new ProofTokenMessageHandler(new DefaultDPoPProofTokenFactory(proofKey), tokenEndpointInnerHandler ?? new HttpClientHandler());
+        var apiDpopHandler = new ProofTokenMessageHandler(new DefaultDPoPProofTokenFactory(proofKey), apiInnerHandler ?? new HttpClientHandler());
+
+        options.BackchannelHandler = tokenDpopHandler;
+        options.RefreshTokenInnerHttpHandler = apiDpopHandler;
+    }
+
+    /// <summary>
+    /// Configure back-channel handlers for DPoP
+    /// </summary>
+    /// <param name="options">The OidcClient options</param>
+    /// <param name="proofTokenFactory">An instance of an implementation of <c ref="IDPoPProofTokenFactory"/></param>
+    /// <param name="tokenEndpointInnerHandler">The inner handler for the token endpoint (optional)</param>
+    /// <param name="apiInnerHandler">The inner handler for API calls (optional)</param>
+    public static void ConfigureDPoP(this OidcClientOptions options,
+        IDPoPProofTokenFactory proofTokenFactory,
+        HttpMessageHandler? tokenEndpointInnerHandler = null,
+        HttpMessageHandler? apiInnerHandler = null)
+    {
+        var tokenDpopHandler = new ProofTokenMessageHandler(proofTokenFactory, tokenEndpointInnerHandler ?? new HttpClientHandler());
+        var apiDpopHandler = new ProofTokenMessageHandler(proofTokenFactory, apiInnerHandler ?? new HttpClientHandler());
 
         options.BackchannelHandler = tokenDpopHandler;
         options.RefreshTokenInnerHttpHandler = apiDpopHandler;
@@ -35,12 +54,37 @@ public static class OidcClientExtensions
     /// <param name="refreshToken">The refresh token</param>
     /// <param name="apiInnerHandler">The inner handler (optional)</param>
     /// <returns></returns>
-    public static HttpMessageHandler CreateDPoPHandler(this Duende.IdentityModel.OidcClient.OidcClient client,
+    public static HttpMessageHandler CreateDPoPHandler(this OidcClient client,
         string proofKey,
         string refreshToken,
         HttpMessageHandler? apiInnerHandler = null)
     {
-        var apiDpopHandler = new ProofTokenMessageHandler(proofKey, apiInnerHandler ?? new HttpClientHandler());
+        var apiDpopHandler = new ProofTokenMessageHandler(new DefaultDPoPProofTokenFactory(proofKey), apiInnerHandler ?? new HttpClientHandler());
+
+        var handler = new RefreshTokenDelegatingHandler(
+            client,
+            null,
+            refreshToken,
+            "DPoP",
+            apiDpopHandler);
+
+        return handler;
+    }
+
+    /// <summary>
+    /// Creates a handler for API calls using DPoP and automatic refresh token management
+    /// </summary>
+    /// <param name="client">The OidcClient instance</param>
+    /// <param name="proofTokenFactory">An instance of an implementation of <c ref="IDPoPProofTokenFactory"/></param>
+    /// <param name="refreshToken">The refresh token</param>
+    /// <param name="apiInnerHandler">The inner handler (optional)</param>
+    /// <returns></returns>
+    public static HttpMessageHandler CreateDPoPHandler(this OidcClient client,
+        IDPoPProofTokenFactory proofTokenFactory,
+        string refreshToken,
+        HttpMessageHandler? apiInnerHandler = null)
+    {
+        var apiDpopHandler = new ProofTokenMessageHandler(proofTokenFactory, apiInnerHandler ?? new HttpClientHandler());
 
         var handler = new RefreshTokenDelegatingHandler(
             client,

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/OidcClientExtensions.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/OidcClientExtensions.cs
@@ -31,7 +31,7 @@ public static class OidcClientExtensions
     /// Configure back-channel handlers for DPoP
     /// </summary>
     /// <param name="options">The OidcClient options</param>
-    /// <param name="proofTokenFactory">An instance of an implementation of <c ref="IDPoPProofTokenFactory"/></param>
+    /// <param name="proofTokenFactory">An instance of an implementation of <see cref="IDPoPProofTokenFactory"/></param>
     /// <param name="tokenEndpointInnerHandler">The inner handler for the token endpoint (optional)</param>
     /// <param name="apiInnerHandler">The inner handler for API calls (optional)</param>
     public static void ConfigureDPoP(this OidcClientOptions options,
@@ -75,7 +75,7 @@ public static class OidcClientExtensions
     /// Creates a handler for API calls using DPoP and automatic refresh token management
     /// </summary>
     /// <param name="client">The OidcClient instance</param>
-    /// <param name="proofTokenFactory">An instance of an implementation of <c ref="IDPoPProofTokenFactory"/></param>
+    /// <param name="proofTokenFactory">An instance of an implementation of <see cref="IDPoPProofTokenFactory"/></param>
     /// <param name="refreshToken">The refresh token</param>
     /// <param name="apiInnerHandler">The inner handler (optional)</param>
     /// <returns></returns>

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/ProofTokenMessageHandler.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/ProofTokenMessageHandler.cs
@@ -8,15 +8,15 @@ namespace Duende.IdentityModel.OidcClient.DPoP;
 /// </summary>
 public class ProofTokenMessageHandler : DelegatingHandler
 {
-    private readonly DPoPProofTokenFactory _proofTokenFactory;
+    private readonly IDPoPProofTokenFactory _proofTokenFactory;
     private string? _nonce;
 
     /// <summary>
     /// Constructor
     /// </summary>
-    public ProofTokenMessageHandler(string proofKey, HttpMessageHandler innerHandler)
+    public ProofTokenMessageHandler(IDPoPProofTokenFactory dPoPProofTokenFactory, HttpMessageHandler innerHandler)
     {
-        _proofTokenFactory = new DPoPProofTokenFactory(proofKey);
+        _proofTokenFactory = dPoPProofTokenFactory ?? throw new ArgumentNullException(nameof(dPoPProofTokenFactory));
         InnerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
     }
 


### PR DESCRIPTION
**What issue does this PR address?**
Added IDPoPProofTokenFactory to allow for customizations to how proof tokens are generated. This came from a [community request](https://github.com/orgs/DuendeSoftware/discussions/163) for more flexibility.

As part of these changes, DPoPProofTokenFactory was renamed to DefaultDPoPProofTokenFactory to make it clear it is the default behavior.

New extensions methods were added for when a user wishes to supply their own implementation of IDPoPProofTokenFactory. Otherwise the existing extension methods will continue to work for existing code