### PR TITLE
GetCacheKey allows nullable string to be passed in

### DIFF
--- a/access-token-management/src/AccessTokenManagement/Internal/DefaultClientCredentialsCacheKeyGenerator.cs
+++ b/access-token-management/src/AccessTokenManagement/Internal/DefaultClientCredentialsCacheKeyGenerator.cs
@@ -20,8 +20,8 @@ internal class DefaultClientCredentialsCacheKeyGenerator(
         ClientCredentialsClientName clientName,
         TokenRequestParameters? parameters = null)
     {
-        var scopePart = "s_" + GetCacheKey(parameters?.Scope ?? string.Empty);
-        var resourcePart = "r_" + GetCacheKey(parameters?.Resource ?? string.Empty);
+        var scopePart = "s_" + GetCacheKey(parameters?.Scope);
+        var resourcePart = "r_" + GetCacheKey(parameters?.Resource);
 
         return ClientCredentialsCacheKey.Parse(options.Value.CacheKeyPrefix + clientName + "::" + scopePart + "::" +
                                                resourcePart);


### PR DESCRIPTION
**What issue does this PR address?**

While working on `GetCacheKey`, a suggested refactor was that we allow a nullable string, but the call site was never adjusted.