### PR TITLE
Ignore the warning around using prerelease packages when a non-prerelease version of a package is being produced

### DIFF
--- a/src.props
+++ b/src.props
@@ -20,6 +20,8 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <!--There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping or specify a single package source.-->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
+    <!-- This warning is triggered when a stable package depends on a prerelease package. -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
 
     <!--NuGet-->
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
**What issue does this PR address?**
As `main` is destined to also support .NET 10, the current dependencies target pre-release packages. We want to ignore the warning about using pre-release packages.

This allows us to ship preview packages that targets .NET 10.

