### PR TITLE
Update Introspection Tests to Use HostBuilder

### DIFF
--- a/introspection/test/AspNetCore.Authentication.OAuth2Introspection.Tests/Configuration.cs
+++ b/introspection/test/AspNetCore.Authentication.OAuth2Introspection.Tests/Configuration.cs
@@ -9,50 +9,57 @@ namespace Duende.AspNetCore.Authentication.OAuth2Introspection;
 public class Configuration
 {
     [Fact]
-    public void Empty_Options()
+    public async Task Empty_Options()
     {
-        var act = () => PipelineFactory.CreateClient(options => { })
-            .GetAsync("http://test").GetAwaiter().GetResult();
+        var client = await PipelineFactory.CreateClient(_ => { });
 
-        act.ShouldThrow<InvalidOperationException>().Message.ShouldBe("You must either set Authority or IntrospectionEndpoint");
+        var act = async () => await client.GetAsync("http://test");
+
+        var result = await act.ShouldThrowAsync<InvalidOperationException>();
+        result.Message.ShouldBe("You must either set Authority or IntrospectionEndpoint");
     }
 
     [Fact]
-    public void Endpoint_But_No_Authority()
+    public async Task Endpoint_But_No_Authority()
     {
-        var act = () => PipelineFactory.CreateClient(options =>
+        var client = await PipelineFactory.CreateClient(options =>
         {
             options.IntrospectionEndpoint = "http://endpoint";
             options.ClientId = "scope";
 
-        }).GetAsync("http://test").GetAwaiter().GetResult();
+        });
 
-        act.ShouldNotThrow();
+        var act = async () => await client.GetAsync("http://test");
+
+        await act.ShouldNotThrowAsync();
     }
 
     [Fact]
-    public void No_ClientName_But_Introspection_Handler()
+    public async Task No_ClientName_But_Introspection_Handler()
     {
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
-
-        var act = () => PipelineFactory.CreateClient(options =>
+        var client = await PipelineFactory.CreateClient(options =>
         {
             options.IntrospectionEndpoint = "http://endpoint";
-        }, handler).GetAsync("http://test").GetAwaiter().GetResult();
+        }, handler);
 
-        act.ShouldNotThrow();
+        var act = async () => await client.GetAsync("http://test");
+
+        await act.ShouldNotThrowAsync();
     }
 
     [Fact]
-    public void Authority_No_Network_Delay_Load()
+    public async Task Authority_No_Network_Delay_Load()
     {
-        var act = () => PipelineFactory.CreateClient(options =>
+        var client = await PipelineFactory.CreateClient(options =>
         {
             options.Authority = "http://localhost:6666";
             options.ClientId = "scope";
-        }).GetAsync("http://test").GetAwaiter().GetResult();
+        });
 
-        act.ShouldNotThrow();
+        var act = async () => await client.GetAsync("http://test");
+
+        await act.ShouldNotThrowAsync();
     }
 
     [Fact]
@@ -61,7 +68,7 @@ public class Configuration
         OAuth2IntrospectionOptions ops = null!;
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
 
-        var client = PipelineFactory.CreateClient(options =>
+        var client = await PipelineFactory.CreateClient(options =>
         {
             options.Authority = "https://authority.com/";
             options.ClientId = "scope";

--- a/introspection/test/AspNetCore.Authentication.OAuth2Introspection.Tests/Introspection.cs
+++ b/introspection/test/AspNetCore.Authentication.OAuth2Introspection.Tests/Introspection.cs
@@ -39,7 +39,7 @@ public class Introspection
     {
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Unauthorized);
 
-        var client = PipelineFactory.CreateClient(o => _options(o), handler);
+        var client = await PipelineFactory.CreateClient(o => _options(o), handler);
         client.SetBearerToken("sometoken");
 
         var result = await client.GetAsync("http://test");
@@ -51,7 +51,7 @@ public class Introspection
     {
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
 
-        var client = PipelineFactory.CreateClient(_options, handler);
+        var client = await PipelineFactory.CreateClient(_options, handler);
         client.SetBearerToken("sometoken");
 
         var result = await client.GetAsync("http://test");
@@ -76,7 +76,7 @@ public class Introspection
 
         var requestCount = 0;
 
-        var messageHandler = PipelineFactory.CreateHandler(o =>
+        var messageHandler = await PipelineFactory.CreateHandler(o =>
         {
             _options(o);
 
@@ -129,7 +129,7 @@ public class Introspection
         var waitForTheSecondRequestToStart = new ManualResetEvent(initialState: false);
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
 
-        var messageHandler = PipelineFactory.CreateHandler(o =>
+        var messageHandler = await PipelineFactory.CreateHandler(o =>
         {
             _options(o);
 
@@ -173,7 +173,7 @@ public class Introspection
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
         var count = 0;
 
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
             o.ClientSecret = null;
@@ -221,7 +221,7 @@ public class Introspection
         bool? validatedCalled = null;
         bool? failureCalled = null;
 
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
 
@@ -256,7 +256,7 @@ public class Introspection
     {
         var introspectionCalls = 0;
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active, TimeSpan.FromHours(1));
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
 
@@ -284,7 +284,7 @@ public class Introspection
     {
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active, TimeSpan.FromMinutes(5));
 
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
 
@@ -305,7 +305,7 @@ public class Introspection
     {
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Inactive);
 
-        var client = PipelineFactory.CreateClient(o => _options(o), handler);
+        var client = await PipelineFactory.CreateClient(o => _options(o), handler);
         client.SetBearerToken("sometoken");
 
         var result = await client.GetAsync("http://test");
@@ -319,7 +319,7 @@ public class Introspection
         bool? validatedCalled = null;
         bool? failureCalled = null;
 
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
 
@@ -355,7 +355,7 @@ public class Introspection
         var expectedToken = "expected_token";
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
 
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
 
@@ -380,7 +380,7 @@ public class Introspection
         var expectedToken = "expected_token";
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active, TimeSpan.FromHours(1));
 
-        var server = PipelineFactory.CreateServer(o =>
+        var server = await PipelineFactory.CreateServer(o =>
         {
             _options(o);
 
@@ -411,7 +411,7 @@ public class Introspection
         var cacheKeyPrefix = "KeyPrefix";
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active, TimeSpan.FromHours(1));
 
-        var server = PipelineFactory.CreateServer(o =>
+        var server = await PipelineFactory.CreateServer(o =>
         {
             _options(o);
 
@@ -442,7 +442,7 @@ public class Introspection
         var expectedToken = "expected_token";
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active, TimeSpan.FromHours(1));
 
-        var server = PipelineFactory.CreateServer(o =>
+        var server = await PipelineFactory.CreateServer(o =>
         {
             _options(o);
 
@@ -469,7 +469,7 @@ public class Introspection
         var expectedToken = "expected_token";
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Inactive);
 
-        var server = PipelineFactory.CreateServer(o =>
+        var server = await PipelineFactory.CreateServer(o =>
         {
             _options(o);
 
@@ -496,7 +496,7 @@ public class Introspection
     {
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
 
-        var client = PipelineFactory.CreateClient(o => _options(o), handler);
+        var client = await PipelineFactory.CreateClient(o => _options(o), handler);
         client.SetBearerToken("sometoken");
 
         handler.IsDiscoveryFailureTest = true;
@@ -512,7 +512,7 @@ public class Introspection
     {
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active);
 
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
 
@@ -538,7 +538,7 @@ public class Introspection
         var introspectionRequestsMade = 0;
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active, TimeSpan.FromMilliseconds(250));
 
-        var client = PipelineFactory.CreateClient(o =>
+        var client = await PipelineFactory.CreateClient(o =>
         {
             _options(o);
 
@@ -570,7 +570,7 @@ public class Introspection
         var token = "sometoken";
         var handler = new IntrospectionEndpointHandler(IntrospectionEndpointHandler.Behavior.Active, TimeSpan.FromMinutes(5));
 
-        var server = PipelineFactory.CreateServer(o =>
+        var server = await PipelineFactory.CreateServer(o =>
         {
             _options(o);
 


### PR DESCRIPTION
**What issue does this PR address?**
Updates introspection tests to replace the use of the deprecated `WebHostBuilder`

