### PR TITLE
Introduce a Token Cache Duration Store

### DIFF
--- a/access-token-management/src/AccessTokenManagement/Internal/ClientCredentialsCacheDurationStore.cs
+++ b/access-token-management/src/AccessTokenManagement/Internal/ClientCredentialsCacheDurationStore.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Options;
+
+namespace Duende.AccessTokenManagement.Internal;
+
+/// <summary>
+/// Store for cache duration auto-tuning state.
+/// </summary>
+internal sealed class ClientCredentialsCacheDurationStore(
+    IOptions<ClientCredentialsTokenManagementOptions> options,
+    TimeProvider time)
+{
+    private readonly ClientCredentialsTokenManagementOptions _options = options.Value;
+    private readonly ConcurrentDictionary<ClientCredentialsCacheKey, TimeSpan> _cacheDurations = new();
+
+    /// <summary>
+    /// Gets the cache duration for a given cache key, or returns the default value if not found.
+    /// </summary>
+    public TimeSpan GetExpiration(ClientCredentialsCacheKey cacheKey)
+    {
+        var cacheExpiration = _options.UseCacheAutoTuning
+            ? _cacheDurations.GetValueOrDefault(cacheKey, _options.DefaultCacheLifetime)
+            : _options.DefaultCacheLifetime;
+        return cacheExpiration;
+    }
+
+    /// <summary>
+    /// Sets the cache duration for a given cache key.
+    /// </summary>
+    public TimeSpan SetExpiration(ClientCredentialsCacheKey cacheKey, DateTimeOffset expiration)
+    {
+        if (!_options.UseCacheAutoTuning
+            || expiration == DateTimeOffset.MaxValue)
+        {
+            return _options.DefaultCacheLifetime;
+        }
+
+        // Calculate how long this access token should be valid in the cache.
+        // Note, the expiration time was just calculated by adding time.GetUTcNow() to the token lifetime.
+        // so for now it's safe to subtract this time from the expiration time.
+
+        var calculated = expiration
+                         - time.GetUtcNow()
+                         - TimeSpan.FromSeconds(_options.CacheLifetimeBuffer);
+
+        _cacheDurations[cacheKey] = calculated;
+
+        return calculated;
+    }
+}

--- a/access-token-management/src/AccessTokenManagement/Internal/Generated/Microsoft.Gen.Logging/Microsoft.Gen.Logging.LoggingGenerator/Logging.cs
+++ b/access-token-management/src/AccessTokenManagement/Internal/Generated/Microsoft.Gen.Logging/Microsoft.Gen.Logging.LoggingGenerator/Logging.cs
@@ -973,7 +973,7 @@ namespace Duende.AccessTokenManagement.Internal
         /// Logs "Caching access token for client: {ClientName}. Expiration: {Expiration}".
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Gen.Logging", "9.9.0.0")]
-        public static  void CachingAccessToken(this global::Microsoft.Extensions.Logging.ILogger logger, global::Microsoft.Extensions.Logging.LogLevel logLevel, global::Duende.AccessTokenManagement.ClientCredentialsClientName clientName, global::System.DateTimeOffset expiration)
+        public static  void CachingAccessToken(this global::Microsoft.Extensions.Logging.ILogger logger, global::Microsoft.Extensions.Logging.LogLevel logLevel, global::Duende.AccessTokenManagement.ClientCredentialsClientName clientName, global::System.TimeSpan cacheDuration)
         {
             if (!logger.IsEnabled(logLevel))
             {
@@ -985,7 +985,7 @@ namespace Duende.AccessTokenManagement.Internal
             _ = state.ReserveTagSpace(3);
             state.TagArray[2] = new("{OriginalFormat}", "Caching access token for client: {ClientName}. Expiration: {Expiration}");
             state.TagArray[1] = new("ClientName", clientName.ToString());
-            state.TagArray[0] = new("Expiration", expiration);
+            state.TagArray[0] = new("CacheDuration", cacheDuration);
 
             logger.Log(
                 logLevel,

--- a/access-token-management/src/AccessTokenManagement/ServiceCollectionExtensions.cs
+++ b/access-token-management/src/AccessTokenManagement/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services)
     {
         services.TryAddTransient<IClientCredentialsTokenManager, ClientCredentialsTokenManager>();
+        services.TryAddSingleton<ClientCredentialsCacheDurationStore>();
         services.AddHybridCache();
 
         // Add a default serializer for ClientCredentialsToken

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/FakeHybridCache.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/FakeHybridCache.cs
@@ -13,20 +13,27 @@ public class FakeHybridCache : HybridCache
 
     public Action OnGetOrCreate = () => { };
 
-    public override async ValueTask<T> GetOrCreateAsync<TState, T>(string key, TState state, Func<TState, CancellationToken, ValueTask<T>> factory, HybridCacheEntryOptions? options = null,
+    public HybridCacheEntryOptions? LastOptions { get; private set; }
+
+    public override async ValueTask<T> GetOrCreateAsync<TState, T>(string key, TState state,
+        Func<TState, CancellationToken, ValueTask<T>> factory, HybridCacheEntryOptions? options = null,
         IEnumerable<string>? tags = null, CancellationToken cancellationToken = new())
     {
         CacheKey = key;
+        LastOptions = options;
         Interlocked.Increment(ref GetOrCreateCount);
         OnGetOrCreate();
         return await factory(state, cancellationToken);
     }
 
-    public override ValueTask SetAsync<T>(string key, T value, HybridCacheEntryOptions? options = null, IEnumerable<string>? tags = null,
+    public override ValueTask SetAsync<T>(string key, T value, HybridCacheEntryOptions? options = null,
+        IEnumerable<string>? tags = null,
         CancellationToken cancellationToken = new()) =>
         throw new NotImplementedException();
 
-    public override ValueTask RemoveAsync(string key, CancellationToken cancellationToken = new()) => throw new NotImplementedException();
+    public override ValueTask RemoveAsync(string key, CancellationToken cancellationToken = new()) =>
+        throw new NotImplementedException();
 
-    public override ValueTask RemoveByTagAsync(string tag, CancellationToken cancellationToken = new()) => throw new NotImplementedException();
+    public override ValueTask RemoveByTagAsync(string tag, CancellationToken cancellationToken = new()) =>
+        throw new NotImplementedException();
 }


### PR DESCRIPTION
We are pulling out the cache duration storage from the token manager by introducing a new service and registering that as a singleton.

This allows us to control the lifetime of the token cache duration outside of the token manager, which might have conflicting lifetimes.

**What issue does this PR address?**
Fixes https://github.com/DuendeSoftware/foss/issues/287

