### PR TITLE
Enable ForceTokenRenewal of OIDC User Access Token

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserAccessTokenRetriever.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserAccessTokenRetriever.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using Duende.AccessTokenManagement.DPoP;
+
 namespace Duende.AccessTokenManagement.OpenIdConnect.Internal;
 
 internal class OpenIdConnectUserAccessTokenRetriever(
@@ -20,7 +22,8 @@ internal class OpenIdConnectUserAccessTokenRetriever(
             ChallengeScheme = _parameters.ChallengeScheme,
             Scope = _parameters.Scope,
             Resource = _parameters.Resource,
-            Context = _parameters.Context
+            Context = _parameters.Context,
+            ForceTokenRenewal = request.GetForceRenewal()
         };
 
         var customizedParameters = customizer != null

--- a/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandler/Helpers/FakeAuthenticationService.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandler/Helpers/FakeAuthenticationService.cs
@@ -9,29 +9,35 @@ using Microsoft.AspNetCore.Http;
 
 namespace Duende.AccessTokenManagement.AccessTokenHandler.Helpers;
 
-public class FakeAuthenticationService(IStoreTokensInAuthenticationProperties storeTokens, TestAccessTokens testTokens) : IAuthenticationService
+public class FakeAuthenticationService(
+    IStoreTokensInAuthenticationProperties storeTokens,
+    TestAccessTokens testAccessTokens)
+    : IAuthenticationService
 {
     public ClaimsPrincipal Principal = new(new ClaimsIdentity([new Claim(JwtClaimTypes.Subject, "sub")], "test"));
 
-    public Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme) =>
-        Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(Principal, BuildProperties(), "oidc")));
+    public async Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme)
+    {
+        var properties = await BuildProperties();
+        return AuthenticateResult.Success(new AuthenticationTicket(Principal, properties, "oidc"));
+    }
 
-    private AuthenticationProperties? BuildProperties()
+    private async Task<AuthenticationProperties> BuildProperties()
     {
         var properties = new AuthenticationProperties();
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        storeTokens.SetUserTokenAsync(testTokens.UserToken, properties);
-#pragma warning restore CS0618 // Type or member is obsolete
-
+        await storeTokens.SetUserTokenAsync(testAccessTokens.UserToken, properties);
         return properties;
     }
 
-    public Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties) => Task.CompletedTask;
+    public Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties) =>
+        Task.CompletedTask;
 
-    public Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties) => Task.CompletedTask;
+    public Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties) =>
+        Task.CompletedTask;
 
-    public Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal, AuthenticationProperties? properties) => Task.CompletedTask;
+    public Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal,
+        AuthenticationProperties? properties) => Task.CompletedTask;
 
-    public Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties) => Task.CompletedTask;
+    public Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties) =>
+        Task.CompletedTask;
 }

--- a/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandler/Helpers/TestAccessTokens.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandler/Helpers/TestAccessTokens.cs
@@ -15,7 +15,11 @@ public class TestAccessTokens(DPoPProofKey? dPoPJsonWebKey)
             IdentityToken = IdentityToken.Parse("identity_token"),
             AccessToken = AccessToken.Parse("access_token_1"),
             AccessTokenType = AccessTokenType.Parse("Bearer"),
-            Expiration = DateTimeOffset.UtcNow.AddMinutes(5),
+            /*
+             * Expiring the token allows us to exercise the Token Endpoint instead of relying on the token retrieved
+             * from the authentication service
+             */
+            Expiration = DateTimeOffset.UtcNow.AddSeconds(-1),
             RefreshToken = RefreshToken.Parse("refresh_token"),
             DPoPJsonWebKey = dPoPJsonWebKey
         };


### PR DESCRIPTION
**What issue does this PR address?**

We want to allow the ability to force the refresh of a token via the OIDC User Access Token Retriever.

Note:
- We set the initial token to be expired as we want to exercise the Token Endpoint for retrieving the Access Token. The expired token forces the token to be retrieved from the token endpoint.




