### PR TITLE
explicitly set audience in samples

### DIFF
--- a/access-token-management/samples/WebJarJwt/ClientAssertionService.cs
+++ b/access-token-management/samples/WebJarJwt/ClientAssertionService.cs
@@ -46,7 +46,11 @@ public class ClientAssertionService : IClientAssertionService
         var descriptor = new SecurityTokenDescriptor
         {
             Issuer = config.ClientId.ToString(),
-            Audience = config.TokenEndpoint.GetLeftPart(UriPartial.Authority),
+
+            // Don't use the TokenEndpoint here. Use the Authority as the audience. 
+            // You may expose yourself to a vulnerability, as described in the document below:
+            // https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf
+            Audience = "https://demo.duendesoftware.com",
             Expires = DateTime.UtcNow.AddMinutes(1),
             SigningCredentials = Credential,
 
@@ -87,7 +91,11 @@ public class ClientAssertionService : IClientAssertionService
         var descriptor = new SecurityTokenDescriptor
         {
             Issuer = config.ClientId.ToString(),
-            Audience = config.TokenEndpoint.GetLeftPart(UriPartial.Authority),
+
+            // Don't use the TokenEndpoint here. Use the Authority as the audience. 
+            // You may expose yourself to a vulnerability, as described in the document below:
+            // https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf
+            Audience = "https://demo.duendesoftware.com",
             Expires = DateTime.UtcNow.AddMinutes(1),
             SigningCredentials = Credential,
 

--- a/access-token-management/samples/Worker/ClientAssertionService.cs
+++ b/access-token-management/samples/Worker/ClientAssertionService.cs
@@ -40,7 +40,7 @@ public class ClientAssertionService(IOptionsMonitor<ClientCredentialsClient> opt
             var descriptor = new SecurityTokenDescriptor
             {
                 Issuer = options1.ClientId?.ToString(),
-                Audience = options1.TokenEndpoint?.ToString(),
+                Audience = "https://demo.duendesoftware.com",
                 Expires = DateTime.UtcNow.AddMinutes(1),
                 SigningCredentials = Credential,
 

--- a/access-token-management/samples/WorkerDI/ClientAssertionService.cs
+++ b/access-token-management/samples/WorkerDI/ClientAssertionService.cs
@@ -40,7 +40,7 @@ public class ClientAssertionService(IOptionsMonitor<ClientCredentialsClient> opt
             var descriptor = new SecurityTokenDescriptor
             {
                 Issuer = options1.ClientId!.ToString(),
-                Audience = options1.TokenEndpoint!.ToString(),
+                Audience = "https://demo.duendesoftware.com",
                 Expires = DateTime.UtcNow.AddMinutes(1),
                 SigningCredentials = Credential,
 


### PR DESCRIPTION
There is a vulnerability in the samples: 

The Vulnerability (CVE-2025-27370/CVE-2025-27371):

     - A malicious authorization server can trick a client into creating a JWT with an attacker-controlled aud (audience) claim
     - When the aud is set to the token endpoint URL (e.g., https://attacker.com/connect/token), the attacker can reuse that JWT to impersonate the client at a different
   authorization server that has the same token endpoint path
     - This is called "audience injection" and allows authentication bypass
     
 By explicitly setting the audience to the authorization server's issuer identifier (the authority) rather than the full token endpoint URL, we prevent the vulnerability because:

     - The JWT is now bound to the specific authorization server's issuer
     - Even if an attacker controls a malicious AS, they cannot reuse the JWT at another AS since the audience would be different
     - This aligns with the OIDF remediation guidance that states: "Clients should only insert the correct AS issuer identifier as the aud claim"