### PR TITLE
fix: add missing client_id in device authorization request

### DIFF
--- a/identity-model/src/IdentityModel/Client/HttpClientDeviceFlowExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientDeviceFlowExtensions.cs
@@ -22,6 +22,7 @@ public static class HttpClientDeviceFlowExtensions
         var clone = request.Clone();
 
         clone.Parameters.AddOptional(OidcConstants.AuthorizeRequest.Scope, request.Scope);
+        clone.Parameters.AddRequired(OidcConstants.AuthorizeRequest.ClientId, request.ClientId);
         clone.Method = HttpMethod.Post;
         clone.Prepare();
 


### PR DESCRIPTION
**What issue does this PR address?**

Hi,

This PR fixes a bug in the device authentication. According to [rfc 8628](https://datatracker.ietf.org/doc/html/rfc8628), the device authorization request must contain a `client_id` and optionally a `scope`. 
However, the http client extension you are providing, omits the client id from the request. This causes all device auth requests to fail with: 
```
Device authorization failed: invalid_client - Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method)
```