### PR TITLE
fix: add additional parameters when refreshing/revoking tokens

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserTokenEndpoint.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserTokenEndpoint.cs
@@ -48,7 +48,8 @@ internal class OpenIdConnectUserTokenEndpoint(
             ClientId = oidc.ClientId.ToString(),
             ClientSecret = oidc.ClientSecret.ToString(),
             ClientCredentialStyle = options.Value.ClientCredentialStyle,
-            RefreshToken = refreshToken.RefreshToken.ToString()
+            RefreshToken = refreshToken.RefreshToken.ToString(),
+            Parameters = parameters.Parameters
         };
 
         request.Options.TryAdd(ClientCredentialsTokenManagementDefaults.TokenRequestParametersOptionsName, parameters);
@@ -181,7 +182,9 @@ internal class OpenIdConnectUserTokenEndpoint(
             ClientCredentialStyle = options.Value.ClientCredentialStyle,
 
             Token = refreshToken.ToString(),
-            TokenTypeHint = OidcConstants.TokenTypes.RefreshToken
+            TokenTypeHint = OidcConstants.TokenTypes.RefreshToken,
+
+            Parameters = parameters.Parameters
         };
 
         request.Options.TryAdd(ClientCredentialsTokenManagementDefaults.TokenRequestParametersOptionsName, parameters);


### PR DESCRIPTION
**What issue does this PR address?**

Fixes #312 by adding the additional parameters specified in `UserTokenRequestParameters` to the request to refresh and revoke token requests. 