### PR TITLE
Downgrade 4 ATM user token log messages from Error to Warning

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserTokenEndpoint.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserTokenEndpoint.cs
@@ -129,7 +129,7 @@ internal class OpenIdConnectUserTokenEndpoint(
 
         if (response.IsError)
         {
-            logger.FailedToRefreshAccessToken(LogLevel.Error, response.Error, response.ErrorDescription);
+            logger.FailedToRefreshAccessToken(LogLevel.Warning, response.Error, response.ErrorDescription);
             metrics.TokenRetrievalFailed(request.ClientId, AccessTokenManagementMetrics.TokenRequestType.User, response.Error);
             return TokenResult.Failure(response.Error ?? "Failed to acquire access token", response.ErrorDescription);
         }
@@ -209,7 +209,7 @@ internal class OpenIdConnectUserTokenEndpoint(
 
         if (response.IsError)
         {
-            logger.FailedToRevokeAccessToken(LogLevel.Error, response.Error);
+            logger.FailedToRevokeAccessToken(LogLevel.Warning, response.Error);
         }
     }
 }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/StoreTokensInAuthenticationProperties.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/StoreTokensInAuthenticationProperties.cs
@@ -50,7 +50,7 @@ internal class StoreTokensInAuthenticationProperties(
         var tokens = authenticationProperties.Items.Where(i => i.Key.StartsWith(TokenPrefix)).ToList();
         if (!tokens.Any())
         {
-            logger.FailedToGetUserTokenDueToMissingTokensInCookie(LogLevel.Warning);
+            logger.FailedToGetUserTokenDueToMissingTokensInCookie(LogLevel.Information);
 
             return new FailedResult("No tokens in properties");
         }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/StoreTokensInAuthenticationProperties.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/StoreTokensInAuthenticationProperties.cs
@@ -50,7 +50,7 @@ internal class StoreTokensInAuthenticationProperties(
         var tokens = authenticationProperties.Items.Where(i => i.Key.StartsWith(TokenPrefix)).ToList();
         if (!tokens.Any())
         {
-            logger.FailedToGetUserTokenDueToMissingTokensInCookie(LogLevel.Error);
+            logger.FailedToGetUserTokenDueToMissingTokensInCookie(LogLevel.Warning);
 
             return new FailedResult("No tokens in properties");
         }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/UserAccessTokenManagementService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/UserAccessTokenManagementService.cs
@@ -36,7 +36,7 @@ internal class UserAccessAccessTokenManager(
 
         if (!user.Identity!.IsAuthenticated)
         {
-            logger.CannotRetrieveAccessTokenDueToNoActiveUser(LogLevel.Warning);
+            logger.CannotRetrieveAccessTokenDueToNoActiveUser(LogLevel.Information);
             return TokenResult.Failure("No active user");
         }
 

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/UserAccessTokenManagementService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/UserAccessTokenManagementService.cs
@@ -36,7 +36,7 @@ internal class UserAccessAccessTokenManager(
 
         if (!user.Identity!.IsAuthenticated)
         {
-            logger.CannotRetrieveAccessTokenDueToNoActiveUser(LogLevel.Error);
+            logger.CannotRetrieveAccessTokenDueToNoActiveUser(LogLevel.Warning);
             return TokenResult.Failure("No active user");
         }
 


### PR DESCRIPTION
## Summary

Downgrades 4 log messages in `Duende.AccessTokenManagement.OpenIdConnect` from `LogLevel.Error` to `LogLevel.Warning`. These conditions represent normal authentication lifecycle events (expired sessions, expired refresh tokens) rather than application errors.

Related: #311

## Problem

Users report that these Error-level log messages trigger unnecessary production alerts. They cannot selectively filter them because turning off all errors in the `Duende` namespace would also hide genuine errors.

## Changes

| File | Log Method | Rationale |
|------|-----------|-----------|
| `UserAccessTokenManagementService.cs:39` | `CannotRetrieveAccessTokenDueToNoActiveUser` | Fires when `user.Identity.IsAuthenticated` is false — expected when session expires |
| `StoreTokensInAuthenticationProperties.cs:53` | `FailedToGetUserTokenDueToMissingTokensInCookie` | Commonly occurs due to expired sessions that resolve via login redirect |
| `OpenIdConnectUserTokenEndpoint.cs:132` | `FailedToRefreshAccessToken` | Refresh token expiration/revocation is part of normal token lifecycle |
| `OpenIdConnectUserTokenEndpoint.cs:212` | `FailedToRevokeAccessToken` | Revocation is best-effort; failure doesn't propagate and tokens expire naturally |

## What stays at Error

`FailedToRequestAccessTokenForClient` (client credentials) remains at `LogLevel.Error` — client credentials failures are not related to user session lifecycle and could indicate genuine infrastructure problems.

## Consistency

This also resolves a log level inconsistency in the pipeline:
- **Before:** `Information` → **`Error`** → `Warning` 
- **After:** `Information` → **`Warning`** → `Warning`