### PR TITLE
Build fixes for razor-slices sample files

### DIFF
--- a/razor-slices/samples/PagesAndSlices/PagesAndSlices.csproj
+++ b/razor-slices/samples/PagesAndSlices/PagesAndSlices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <!-- Reference the props that would be brought in when consuming the RazorSlices package -->
-  <Import Project="..\..\src\RazorSlices\build\RazorSlices.props" />
+  <Import Project="..\..\src\RazorSlices\build\Duende.RazorSlices.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -22,6 +22,6 @@
   </ItemGroup>
 
   <!-- Reference the targets that would be brought in when consuming the RazorSlices package -->
-  <Import Project="..\..\src\RazorSlices\build\RazorSlices.targets" />
+  <Import Project="..\..\src\RazorSlices\build\Duende.RazorSlices.targets" />
 
 </Project>

--- a/razor-slices/samples/RazorClassLibrary/RazorClassLibrary.csproj
+++ b/razor-slices/samples/RazorClassLibrary/RazorClassLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <!-- Reference the props that would be brought in when consuming the RazorSlices package -->
-  <Import Project="..\..\src\RazorSlices\build\RazorSlices.props" />
+  <Import Project="..\..\src\RazorSlices\build\Duende.RazorSlices.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -22,6 +22,6 @@
   </ItemGroup>
 
   <!-- Reference the targets that would be brought in when consuming the RazorSlices package -->
-  <Import Project="..\..\src\RazorSlices\build\RazorSlices.targets" />
+  <Import Project="..\..\src\RazorSlices\build\Duende.RazorSlices.targets" />
 
 </Project>

--- a/razor-slices/samples/RazorClassLibrary/Slices/FromLibrary.cshtml.cs
+++ b/razor-slices/samples/RazorClassLibrary/Slices/FromLibrary.cshtml.cs
@@ -1,3 +1,5 @@
+using Duende.RazorSlices;
+
 namespace RazorSlices.Samples.RazorClassLibrary.Slices;
 
 public partial class FromLibrary

--- a/razor-slices/samples/WebApp/MapSlices.cs
+++ b/razor-slices/samples/WebApp/MapSlices.cs
@@ -1,3 +1,4 @@
+using Duende.RazorSlices;
 using LibrarySlices = RazorSlices.Samples.RazorClassLibrary.Slices;
 using Microsoft.AspNetCore.Http.HttpResults;
 using System.Text;

--- a/razor-slices/samples/WebApp/WebApp.csproj
+++ b/razor-slices/samples/WebApp/WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
- 
+
    <!-- Reference the props that would be brought in when consuming the RazorSlices package -->
-   <Import Project="..\..\src\RazorSlices\build\RazorSlices.props" />
+   <Import Project="..\..\src\RazorSlices\build\Duende.RazorSlices.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -18,7 +18,7 @@
     <!--<PublishSingleFile>true</PublishSingleFile>-->
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\RazorSlices\RazorSlices.csproj" />
     <ProjectReference Include="..\RazorClassLibrary\RazorClassLibrary.csproj" />
@@ -30,6 +30,6 @@
   </ItemGroup>
 
   <!-- Reference the targets that would be brought in when consuming the RazorSlices package -->
-  <Import Project="..\..\src\RazorSlices\build\RazorSlices.targets" />
+  <Import Project="..\..\src\RazorSlices\build\Duende.RazorSlices.targets" />
 
 </Project>


### PR DESCRIPTION
## Summary

Fixes build failures in the `razor-slices` samples caused by missing `using Duende.RazorSlices;` directives.

- Add `using Duende.RazorSlices;` to `samples/RazorClassLibrary/Slices/FromLibrary.cshtml.cs` so the `RenderAsync()` string extension method resolves
- Add `using Duende.RazorSlices;` to `samples/WebApp/MapSlices.cs` so the `RenderAsync(Stream)`, `RenderAsync(StringBuilder)`, `RenderAsync()` extension methods and the `RazorSlice` type reference resolve
- Fix the imports of the razor slices props and targets in the samples