### PR TITLE
Add test runner to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
This opts us in to the new testing experience, and resolves the "Testing with VSTest target is no longer supported by Microsoft.Testing.Platform on .NET 10 SDK and later. If you use dotnet test, you should opt-in to the new dotnet test experience." errors.




