### PR TITLE
Create client assertions on demand 

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,109 @@
+## Summary
+
+When a token endpoint returns a DPoP nonce (401 with `DPoP-Nonce` header), `ProofTokenMessageHandler` retries the request using the **same request object**, which carries the **same `ClientAssertion`** (same `jti`, `iat`, etc.). Servers that enforce client assertion uniqueness (e.g. HelseID) reject the retry as a replay.
+
+Reported in: https://github.com/DuendeSoftware/foss/issues/323
+
+## Root Cause
+
+The retry path in `ProofTokenMessageHandler.SendAsync()` reuses the original `HttpRequestMessage`. The `ClientAssertion` is set once at request creation time (e.g. in `ResponseProcessor.RedeemCodeAsync()`) and never regenerated for the retry.
+
+Additionally, `ProtocolRequest.Clone<T>()` copies `ClientAssertion` **by reference** (shallow copy), so even cloned requests share the same assertion object — though the real issue is the JWT string itself being identical.
+
+### Call chain
+
+```
+ResponseProcessor.RedeemCodeAsync()
+  → AuthorizationCodeTokenRequest created with ClientAssertion (fetched once)
+    → HttpClientTokenRequestExtensions clones via ProtocolRequest.Clone<T>()
+      → Clone() shallow-copies ClientAssertion
+        → ProofTokenMessageHandler.SendAsync() retries on DPoP nonce
+          → Same ClientAssertion reused on retry ← BUG
+```
+
+## Affected Code
+
+| File | Package | Role |
+|------|---------|------|
+| `ProofTokenMessageHandler.cs` (L42-44) | oidc-client-extensions | Retries request with same object on DPoP nonce |
+| `ProtocolRequest.cs` (L103) | identity-model | `Clone()` shallow-copies `ClientAssertion` |
+| `ResponseProcessor.cs` (L184) | oidc-client | Sets client assertion once at request creation |
+| `HttpClientTokenRequestExtensions.cs` | identity-model | Calls `Clone()` + `Prepare()` on all token requests |
+| `AuthorizationServerDPoPHandler.cs` | access-token-management | Same retry pattern, same bug |
+
+## Scope
+
+Affects **all token request types** using client assertions + DPoP:
+- Authorization code exchange
+- Refresh token requests
+- Client credentials requests
+- PAR requests
+- Device authorization
+
+## Expected Behavior
+
+Each token request attempt (including DPoP nonce retries) should use a **unique client assertion** with a fresh `jti` and `iat`, per RFC 7521 §4.2.
+
+---
+
+## Proposed Fix: Factory on `HttpRequestMessage.Options` (Strategy C)
+
+### Approach
+
+Add a `ClientAssertionFactory` (`Func<Task<ClientAssertion>>?`) property to `ProtocolRequest` that flows through `Clone()` → `Prepare()` → `HttpRequestMessage.Options` → handler chain. On DPoP nonce retry, `ProofTokenMessageHandler` checks for the factory, calls it to get a fresh assertion, and rebuilds the form body.
+
+### Why this strategy
+
+- **Backward compatible** — additive only, defaults to null, no behavioral change when unset
+- **Minimal coupling** — the handler only needs to know about `client_assertion` / `client_assertion_type` form fields
+- **Uses standard .NET patterns** — `HttpRequestMessage.Options` is the idiomatic way to pass data through handler chains
+- **Works at the right level** — the factory is set by callers who have access to key material, and consumed by the handler that performs the retry
+
+### Alternatives considered and rejected
+
+| Strategy | Why rejected |
+|----------|-------------|
+| A: Pass factory directly to handler constructor | Handler is a `DelegatingHandler` — can't easily access per-request assertion factories |
+| B: Call `Prepare()` again on retry | `Prepare()` is not idempotent (double-adds parameters) and is synchronous |
+| D: Move retry to callers | Major architectural change, duplicates retry logic across all callers |
+
+### Implementation tasks
+
+#### identity-model
+
+- [ ] Add `Func<Task<ClientAssertion>>? ClientAssertionFactory` property to `ProtocolRequest`
+- [ ] Copy `ClientAssertionFactory` in `Clone<T>()`
+- [ ] Define a public `HttpRequestOptionsKey` for the factory (e.g. `ProtocolRequestOptions.ClientAssertionFactory`)
+- [ ] Store the factory on `HttpRequestMessage.Options` in `RequestTokenAsync()` after `Prepare()`
+- [ ] Also store in `PushAuthorizationAsync()` for PAR flow
+- [ ] Update public API verification snapshot
+
+#### identity-model-oidc-client
+
+- [ ] Update `ProofTokenMessageHandler.SendAsync()` retry path to:
+  1. Check for factory in `request.Options`
+  2. Call factory to get fresh `ClientAssertion`
+  3. Parse existing form body as `IEnumerable<KeyValuePair<string, string>>` (preserving duplicate keys)
+  4. Replace `client_assertion` and `client_assertion_type` values
+  5. Rebuild `FormUrlEncodedContent`
+- [ ] Wire `ClientAssertionFactory` in `ResponseProcessor.RedeemCodeAsync()`
+- [ ] Wire `ClientAssertionFactory` in `OidcClient.RefreshTokenAsync()`
+- [ ] Wire `ClientAssertionFactory` in `AuthorizeClient.PushAuthorizationRequestAsync()`
+
+#### access-token-management
+
+- [ ] Fix `AuthorizationServerDPoPHandler` retry path (same pattern as `ProofTokenMessageHandler`)
+- [ ] Evaluate `ClientCredentialsTokenClient` and `OpenIdConnectUserTokenEndpoint` retry paths — they reuse the same `request.ClientAssertion` value across retries
+
+#### Tests
+
+- [ ] Unit test: `ProofTokenMessageHandler` uses fresh assertion on DPoP nonce retry
+- [ ] Unit test: `Clone<T>()` preserves `ClientAssertionFactory`
+- [ ] Unit test: backward compatibility — no factory set, behavior unchanged
+- [ ] Integration test: end-to-end DPoP + client assertion with nonce enforcement
+
+### Implementation notes
+
+- Form body parsing on retry **must** use `IEnumerable<KeyValuePair<string, string>>`, not a dictionary — dictionaries collapse duplicate keys like `resource` (identified during security review)
+- Both `client_assertion` and `client_assertion_type` should be replaced from the factory result to guard against type mismatches
+- `FormUrlEncodedContent` buffers internally, so `ReadAsStringAsync()` works after the first send

--- a/foss.slnx
+++ b/foss.slnx
@@ -50,6 +50,7 @@
     <File Path="identity-model/README.md" />
   </Folder>
   <Folder Name="/identity-model/samples/">
+    <Project Path="identity-model/samples/ClientAssertions/ClientAssertions.csproj" />
     <Project Path="identity-model/samples/HttpClientFactory/HttpClientFactory.csproj" />
   </Folder>
   <Folder Name="/identity-model/src/">

--- a/identity-model-oidc-client/clients/ConsoleClientWithBrowser/Program.cs
+++ b/identity-model-oidc-client/clients/ConsoleClientWithBrowser/Program.cs
@@ -12,7 +12,7 @@ using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using Serilog.Sinks.SystemConsole.Themes;
 
-namespace ConsoleClientWithBrowser;
+namespace NetCoreConsoleClient;
 
 public class Program
 {

--- a/identity-model-oidc-client/clients/ConsoleClientWithBrowser/SystemBrowser.cs
+++ b/identity-model-oidc-client/clients/ConsoleClientWithBrowser/SystemBrowser.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
-namespace ConsoleClientWithBrowser;
+namespace NetCoreConsoleClient;
 
 public class SystemBrowser : IBrowser
 {

--- a/identity-model-oidc-client/samples/HttpSysConsoleClient/README.md
+++ b/identity-model-oidc-client/samples/HttpSysConsoleClient/README.md
@@ -1,6 +1,6 @@
 ## HttpSysConsoleClient Sample
 This sample shows how to use Duende.IdentityModel.OidcClient to build a windows desktop
-application in .NET 8. It uses [manual
+application in .NET. It uses [manual
 mode](https://docs.duendesoftware.com/foss/identitymodel.oidcclient/manual/), and listens
 for callbacks on the loopback address with a hard-coded port.
 
@@ -8,7 +8,7 @@ for callbacks on the loopback address with a hard-coded port.
 This sample first creates an
 [HttpListener](https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-net-httplistener)
 to wait for callbacks from the identity provider at a hard-coded port on the local
-machine. Then it usesDuende.IdentityModel.OidcClient to prepare the state and url needed to
+machine. Then it uses Duende.IdentityModel.OidcClient to prepare the state and url needed to
 login, using that callback url as the redirect uri. It then opens the system browser to
 the authorize url by calling `Process.Start` and passing the url. After the user
 authenticates, the system browser redirects to the callback url. The HttpListener receives
@@ -20,4 +20,4 @@ and cleans up its HttpListener.
 
 ### HTTP.sys
 HttpListener is built on top of the HTTP.sys, the windows driver that handles http
-requests. 
+requests.

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/README.md
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/README.md
@@ -1,6 +1,6 @@
 ## NetCoreConsoleClient Sample
 This sample shows how to use Duende.IdentityModel.OidcClient to build a cross platform desktop
-application in .NET 8. It uses [automatic
+application in .NET. It uses [automatic
 mode](https://docs.duendesoftware.com/foss/identitymodel.oidcclient/automatic/), where an
 IBrowser implementation describes how to invoke the system browser. This sample's browser
 implementation knows how to open the system browser on Windows, Mac, and Linux (see
@@ -9,7 +9,7 @@ server. See SystemBrowser.cs for the full IBrowser implementation details.
 
 ### Description of Implementation
 This sample first finds an unused port to use as a callback url where it sets up a minimal
-kestrel web server listening for callbacks from the identity provider. 
+kestrel web server listening for callbacks from the identity provider.
 
 Then it uses Duende.IdentityModel.OidcClient to begin the login process, passing an
 instance of the SystemBrowser. Behind the scenes, Duende.IdentityModel.OidcClient prepares

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/ClientAssertionService.cs
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/ClientAssertionService.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using NetCoreConsoleClient;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+public class ClientAssertionService
+{
+    private static string RsaKey =
+        """
+        {
+            "d":"GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ",
+            "dp":"YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE",
+            "dq":"LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M",
+            "e":"AQAB",
+            "kid":"ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA",
+            "kty":"RSA",
+            "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw",
+            "p":"7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE",
+            "q":"0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts",
+            "qi":"pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4"
+        }
+        """;
+
+    private static SigningCredentials Credential = new(new JsonWebKey(RsaKey), "RS256");
+
+    public static Task<ClientAssertion> Create(CancellationToken ct = default)
+    {
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Configuration.ClientId,
+
+            // Don't use the TokenEndpoint here. Use the Authority as the audience.
+            // You may expose yourself to a vulnerability, as described in the document below:
+            // https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf
+            Audience = Configuration.Authority,
+            Expires = DateTime.UtcNow.AddMinutes(1),
+            SigningCredentials = Credential,
+
+            Claims = new Dictionary<string, object>
+            {
+                { JwtClaimTypes.JwtId, Guid.NewGuid().ToString() },
+                { JwtClaimTypes.Subject, Configuration.ClientId },
+                { JwtClaimTypes.IssuedAt, DateTimeOffset.UtcNow.ToUnixTimeSeconds() }
+            },
+
+            AdditionalHeaderClaims = new Dictionary<string, object>
+            {
+                { JwtClaimTypes.TokenType, "client-authentication+jwt" }
+            }
+        };
+
+        var handler = new JsonWebTokenHandler();
+        var jwt = handler.CreateToken(descriptor);
+
+        return Task.FromResult(new ClientAssertion
+        {
+            Type = OidcConstants.ClientAssertionTypes.JwtBearer,
+            Value = jwt
+        });
+    }
+}

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/NetCoreConsoleClient.csproj
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/NetCoreConsoleClient.csproj
@@ -11,7 +11,8 @@
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
+    <ProjectReference Include="../../../../src/IdentityModel.OidcClient.Extensions/IdentityModel.OidcClient.Extensions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/Program.cs
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/Program.cs
@@ -1,134 +1,146 @@
-﻿using Duende.IdentityModel.Client;
+﻿// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient.DPoP;
 using Newtonsoft.Json.Linq;
 using Serilog;
 
-namespace ConsoleClientWithBrowser
+namespace NetCoreConsoleClient;
+
+public static class Configuration
 {
-    public class Program
+    public static string Authority = "https://demo.duendesoftware.com";
+    public static string ClientId = "interactive.confidential.jwt.dpop";
+    public static string Api = "https://demo.duendesoftware.com/api/test";
+}
+
+public class Program
+{
+
+
+    static HttpClient _apiClient = new HttpClient { BaseAddress = new Uri(Configuration.Api) };
+
+    public static void Main(string[] args) => MainAsync().GetAwaiter().GetResult();
+
+    public static async Task MainAsync()
     {
-        static string _authority = "https://demo.duendesoftware.com";
-        static string _api = "https://demo.duendesoftware.com/api/test";
+        Console.WriteLine("+-----------------------+");
+        Console.WriteLine("|  Sign in with OIDC    |");
+        Console.WriteLine("+-----------------------+");
+        Console.WriteLine("");
+        Console.WriteLine("Press any key to sign in...");
+        // Console.ReadKey();
 
-        static HttpClient _apiClient = new HttpClient { BaseAddress = new Uri(_api) };
+        await Login();
+    }
 
-        public static void Main(string[] args) => MainAsync().GetAwaiter().GetResult();
+    private static async Task Login()
+    {
+        // create a redirect URI using an available port on the loopback address.
+        // requires the OP to allow random ports on 127.0.0.1 - otherwise set a static port
+        var browser = new SystemBrowser();
+        var redirectUri = string.Format($"http://127.0.0.1:{browser.Port}");
 
-        public static async Task MainAsync()
+        var options = new OidcClientOptions
         {
-            Console.WriteLine("+-----------------------+");
-            Console.WriteLine("|  Sign in with OIDC    |");
-            Console.WriteLine("+-----------------------+");
-            Console.WriteLine("");
-            Console.WriteLine("Press any key to sign in...");
-            Console.ReadKey();
+            Authority = Configuration.Authority,
+            ClientId = Configuration.ClientId,
+            GetClientAssertionAsync = async () => await ClientAssertionService.Create(),
+            RedirectUri = redirectUri,
+            Scope = "openid profile api",
+            FilterClaims = false,
+            Browser = browser,
+        };
+        var proofKey = JsonWebKeys.CreateRsaJson();
+        options.ConfigureDPoP(proofKey);
 
-            await Login();
+        var serilog = new LoggerConfiguration()
+            .MinimumLevel.Error()
+            .Enrich.FromLogContext()
+            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message}{NewLine}{Exception}{NewLine}")
+            .CreateLogger();
+
+        options.LoggerFactory.AddSerilog(serilog);
+
+        var oidcClient = new OidcClient(options);
+        var result = await oidcClient.LoginAsync(new LoginRequest());
+
+        ShowResult(result);
+        await NextSteps(result, oidcClient);
+    }
+
+    private static void ShowResult(LoginResult result)
+    {
+        if (result.IsError)
+        {
+            Console.WriteLine("\n\nError:\n{0}", result.Error);
+            return;
         }
 
-        private static async Task Login()
+        Console.WriteLine("\n\nClaims:");
+        foreach (var claim in result.User.Claims)
         {
-            // create a redirect URI using an available port on the loopback address.
-            // requires the OP to allow random ports on 127.0.0.1 - otherwise set a static port
-            var browser = new SystemBrowser();
-            string redirectUri = string.Format($"http://127.0.0.1:{browser.Port}");
-
-            var options = new OidcClientOptions
-            {
-                Authority = _authority,
-                ClientId = "interactive.public",
-                RedirectUri = redirectUri,
-                Scope = "openid profile api",
-                FilterClaims = false,
-                Browser = browser,
-            };
-
-            var serilog = new LoggerConfiguration()
-                .MinimumLevel.Error()
-                .Enrich.FromLogContext()
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message}{NewLine}{Exception}{NewLine}")
-                .CreateLogger();
-
-            options.LoggerFactory.AddSerilog(serilog);
-
-            var oidcClient = new OidcClient(options);
-            var result = await oidcClient.LoginAsync(new LoginRequest());
-
-            ShowResult(result);
-            await NextSteps(result, oidcClient);
+            Console.WriteLine("{0}: {1}", claim.Type, claim.Value);
         }
 
-        private static void ShowResult(LoginResult result)
+        Console.WriteLine($"\nidentity token: {result.IdentityToken}");
+        Console.WriteLine($"access token:   {result.AccessToken}");
+        Console.WriteLine($"refresh token:  {result?.RefreshToken ?? "none"}");
+    }
+
+    private static async Task NextSteps(LoginResult result, OidcClient oidcClient)
+    {
+        var currentAccessToken = result.AccessToken;
+        var currentRefreshToken = result.RefreshToken;
+
+        var menu = "  x...exit  c...call api   ";
+        if (currentRefreshToken != null) menu += "r...refresh token   ";
+
+        while (true)
         {
-            if (result.IsError)
+            Console.WriteLine("\n\n");
+
+            Console.Write(menu);
+            var key = Console.ReadKey();
+
+            if (key.Key == ConsoleKey.X) return;
+            if (key.Key == ConsoleKey.C) await CallApi(currentAccessToken);
+            if (key.Key == ConsoleKey.R)
             {
-                Console.WriteLine("\n\nError:\n{0}", result.Error);
-                return;
-            }
-
-            Console.WriteLine("\n\nClaims:");
-            foreach (var claim in result.User.Claims)
-            {
-                Console.WriteLine("{0}: {1}", claim.Type, claim.Value);
-            }
-
-            Console.WriteLine($"\nidentity token: {result.IdentityToken}");
-            Console.WriteLine($"access token:   {result.AccessToken}");
-            Console.WriteLine($"refresh token:  {result?.RefreshToken ?? "none"}");
-        }
-
-        private static async Task NextSteps(LoginResult result, OidcClient oidcClient)
-        {
-            var currentAccessToken = result.AccessToken;
-            var currentRefreshToken = result.RefreshToken;
-
-            var menu = "  x...exit  c...call api   ";
-            if (currentRefreshToken != null) menu += "r...refresh token   ";
-
-            while (true)
-            {
-                Console.WriteLine("\n\n");
-
-                Console.Write(menu);
-                var key = Console.ReadKey();
-
-                if (key.Key == ConsoleKey.X) return;
-                if (key.Key == ConsoleKey.C) await CallApi(currentAccessToken);
-                if (key.Key == ConsoleKey.R)
+                var refreshResult = await oidcClient.RefreshTokenAsync(currentRefreshToken);
+                if (refreshResult.IsError)
                 {
-                    var refreshResult = await oidcClient.RefreshTokenAsync(currentRefreshToken);
-                    if (refreshResult.IsError)
-                    {
-                        Console.WriteLine($"Error: {refreshResult.Error}");
-                    }
-                    else
-                    {
-                        currentRefreshToken = refreshResult.RefreshToken;
-                        currentAccessToken = refreshResult.AccessToken;
+                    Console.WriteLine($"Error: {refreshResult.Error}");
+                }
+                else
+                {
+                    currentRefreshToken = refreshResult.RefreshToken;
+                    currentAccessToken = refreshResult.AccessToken;
 
-                        Console.WriteLine("\n\n");
-                        Console.WriteLine($"access token:   {refreshResult.AccessToken}");
-                        Console.WriteLine($"refresh token:  {refreshResult?.RefreshToken ?? "none"}");
-                    }
+                    Console.WriteLine("\n\n");
+                    Console.WriteLine($"access token:   {refreshResult.AccessToken}");
+                    Console.WriteLine($"refresh token:  {refreshResult?.RefreshToken ?? "none"}");
                 }
             }
         }
+    }
 
-        private static async Task CallApi(string currentAccessToken)
+    private static async Task CallApi(string currentAccessToken)
+    {
+        _apiClient.SetBearerToken(currentAccessToken);
+        var response = await _apiClient.GetAsync("");
+
+        if (response.IsSuccessStatusCode)
         {
-            _apiClient.SetBearerToken(currentAccessToken);
-            var response = await _apiClient.GetAsync("");
-
-            if (response.IsSuccessStatusCode)
-            {
-                var json = JArray.Parse(await response.Content.ReadAsStringAsync());
-                Console.WriteLine("\n\n");
-                Console.WriteLine(json);
-            }
-            else
-            {
-                Console.WriteLine($"Error: {response.ReasonPhrase}");
-            }
+            var json = JArray.Parse(await response.Content.ReadAsStringAsync());
+            Console.WriteLine("\n\n");
+            Console.WriteLine(json);
+        }
+        else
+        {
+            Console.WriteLine($"Error: {response.ReasonPhrase}");
         }
     }
 }

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/SystemBrowser.cs
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/SystemBrowser.cs
@@ -1,192 +1,190 @@
-﻿using Duende.IdentityModel.OidcClient.Browser;
+﻿// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Duende.IdentityModel.OidcClient.Browser;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using System;
 using System.Diagnostics;
-using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace ConsoleClientWithBrowser
+namespace NetCoreConsoleClient;
+
+public class SystemBrowser : IBrowser
 {
-    public class SystemBrowser : IBrowser
+    public int Port { get; }
+    private readonly string? _path;
+
+    public SystemBrowser(int? port = null, string? path = null)
     {
-        public int Port { get; }
-        private readonly string? _path;
+        _path = path;
 
-        public SystemBrowser(int? port = null, string? path = null)
+        if (!port.HasValue)
         {
-            _path = path;
-
-            if (!port.HasValue)
-            {
-                Port = GetRandomUnusedPort();
-            }
-            else
-            {
-                Port = port.Value;
-            }
+            Port = GetRandomUnusedPort();
         }
-
-        private int GetRandomUnusedPort()
+        else
         {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            Port = port.Value;
         }
+    }
 
-        public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default(CancellationToken))
+    private int GetRandomUnusedPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default(CancellationToken))
+    {
+        using (var listener = new LoopbackHttpListener(Port, _path))
         {
-            using (var listener = new LoopbackHttpListener(Port, _path))
-            {
-                OpenBrowser(options.StartUrl);
+            OpenBrowser(options.StartUrl);
 
-                try
+            try
+            {
+                var result = await listener.WaitForCallbackAsync();
+                if (String.IsNullOrWhiteSpace(result))
                 {
-                    var result = await listener.WaitForCallbackAsync();
-                    if (String.IsNullOrWhiteSpace(result))
-                    {
-                        return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = "Empty response." };
-                    }
+                    return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = "Empty response." };
+                }
 
-                    return new BrowserResult { Response = result, ResultType = BrowserResultType.Success };
-                }
-                catch (TaskCanceledException ex)
-                {
-                    return new BrowserResult { ResultType = BrowserResultType.Timeout, Error = ex.Message };
-                }
-                catch (Exception ex)
-                {
-                    return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = ex.Message };
-                }
+                return new BrowserResult { Response = result, ResultType = BrowserResultType.Success };
             }
-        }
-
-        public static void OpenBrowser(string url)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            catch (TaskCanceledException ex)
             {
-                Process.Start(new ProcessStartInfo
-                {
-                    FileName = url,
-                    UseShellExecute = true,
-                });
+                return new BrowserResult { ResultType = BrowserResultType.Timeout, Error = ex.Message };
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            catch (Exception ex)
             {
-                Process.Start("xdg-open", url);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                Process.Start("open", url);
+                return new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = ex.Message };
             }
         }
     }
 
-    public class LoopbackHttpListener : IDisposable
+    public static void OpenBrowser(string url)
     {
-        const int DefaultTimeout = 60 * 5; // 5 mins (in seconds)
-
-        IWebHost _host;
-        TaskCompletionSource<string> _source = new TaskCompletionSource<string>();
-        string _url;
-
-        public string Url => _url;
-
-        public LoopbackHttpListener(int port, string? path = null)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            path = path ?? String.Empty;
-            if (path.StartsWith("/")) path = path.Substring(1);
-
-            _url = $"http://127.0.0.1:{port}/{path}";
-
-            _host = new WebHostBuilder()
-                .UseKestrel()
-                .UseUrls(_url)
-                .Configure(Configure)
-                .Build();
-            _host.Start();
-        }
-
-        public void Dispose()
-        {
-            Task.Run(async () =>
+            Process.Start(new ProcessStartInfo
             {
-                await Task.Delay(500);
-                _host.Dispose();
+                FileName = url,
+                UseShellExecute = true,
             });
         }
-
-        void Configure(IApplicationBuilder app)
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            app.Run(async ctx =>
+            Process.Start("xdg-open", url);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            Process.Start("open", url);
+        }
+    }
+}
+
+public class LoopbackHttpListener : IDisposable
+{
+    const int DefaultTimeout = 60 * 5; // 5 mins (in seconds)
+
+    IWebHost _host;
+    TaskCompletionSource<string> _source = new TaskCompletionSource<string>();
+    string _url;
+
+    public string Url => _url;
+
+    public LoopbackHttpListener(int port, string? path = null)
+    {
+        path = path ?? String.Empty;
+        if (path.StartsWith("/")) path = path.Substring(1);
+
+        _url = $"http://127.0.0.1:{port}/{path}";
+
+        _host = new WebHostBuilder()
+            .UseKestrel()
+            .UseUrls(_url)
+            .Configure(Configure)
+            .Build();
+        _host.Start();
+    }
+
+    public void Dispose()
+    {
+        Task.Run(async () =>
+        {
+            await Task.Delay(500);
+            _host.Dispose();
+        });
+    }
+
+    void Configure(IApplicationBuilder app)
+    {
+        app.Run(async ctx =>
+        {
+            if (ctx.Request.Method == "GET")
             {
-                if (ctx.Request.Method == "GET")
+                var result = ctx.Request.QueryString.Value ??
+                    throw new InvalidOperationException("QueryString cannot be null");
+                await SetResultAsync(result, ctx);
+            }
+            else if (ctx.Request.Method == "POST")
+            {
+                if (ctx.Request.ContentType?.Equals("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase) == false)
                 {
-                    var result = ctx.Request.QueryString.Value ??
-                        throw new InvalidOperationException("QueryString cannot be null");
-                    await SetResultAsync(result, ctx);
-                }
-                else if (ctx.Request.Method == "POST")
-                {
-                    if (ctx.Request.ContentType?.Equals("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase) == false)
-                    {
-                        ctx.Response.StatusCode = 415;
-                    }
-                    else
-                    {
-                        using (var sr = new StreamReader(ctx.Request.Body, Encoding.UTF8))
-                        {
-                            var body = await sr.ReadToEndAsync();
-                            await SetResultAsync(body, ctx);
-                        }
-                    }
+                    ctx.Response.StatusCode = 415;
                 }
                 else
                 {
-                    ctx.Response.StatusCode = 405;
+                    using (var sr = new StreamReader(ctx.Request.Body, Encoding.UTF8))
+                    {
+                        var body = await sr.ReadToEndAsync();
+                        await SetResultAsync(body, ctx);
+                    }
                 }
-            });
-        }
-
-        private async Task SetResultAsync(string value, HttpContext ctx)
-        {
-            try
-            {
-                ctx.Response.StatusCode = 200;
-                ctx.Response.ContentType = "text/html";
-                await ctx.Response.WriteAsync("<h1>You can now return to the application.</h1>");
-                await ctx.Response.Body.FlushAsync();
-
-                _source.TrySetResult(value);
             }
-            catch(Exception ex)
+            else
             {
-                Console.WriteLine(ex.ToString());
-
-                ctx.Response.StatusCode = 400;
-                ctx.Response.ContentType = "text/html";
-                await ctx.Response.WriteAsync("<h1>Invalid request.</h1>");
-                await ctx.Response.Body.FlushAsync();
+                ctx.Response.StatusCode = 405;
             }
-        }
+        });
+    }
 
-        public Task<string> WaitForCallbackAsync(int timeoutInSeconds = DefaultTimeout)
+    private async Task SetResultAsync(string value, HttpContext ctx)
+    {
+        try
         {
-            Task.Run(async () =>
-            {
-                await Task.Delay(timeoutInSeconds * 1000);
-                _source.TrySetCanceled();
-            });
+            ctx.Response.StatusCode = 200;
+            ctx.Response.ContentType = "text/html";
+            await ctx.Response.WriteAsync("<h1>You can now return to the application.</h1>");
+            await ctx.Response.Body.FlushAsync();
 
-            return _source.Task;
+            _source.TrySetResult(value);
         }
+        catch(Exception ex)
+        {
+            Console.WriteLine(ex.ToString());
+
+            ctx.Response.StatusCode = 400;
+            ctx.Response.ContentType = "text/html";
+            await ctx.Response.WriteAsync("<h1>Invalid request.</h1>");
+            await ctx.Response.Body.FlushAsync();
+        }
+    }
+
+    public Task<string> WaitForCallbackAsync(int timeoutInSeconds = DefaultTimeout)
+    {
+        Task.Run(async () =>
+        {
+            await Task.Delay(timeoutInSeconds * 1000);
+            _source.TrySetCanceled();
+        });
+
+        return _source.Task;
     }
 }

--- a/identity-model-oidc-client/samples/WindowsConsoleSystemBrowser/README.md
+++ b/identity-model-oidc-client/samples/WindowsConsoleSystemBrowser/README.md
@@ -1,6 +1,6 @@
 ## HttpSysConsoleClient Sample
 This sample shows how to use Duende.IdentityModel.OidcClient to build a windows desktop
-application in .NET 8. It uses [manual
+application in .NET. It uses [manual
 mode](https://docs.duendesoftware.com/foss/identitymodel.oidcclient/manual/), and listens for
 callbacks on a private-use URI scheme.
 

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/ProofTokenMessageHandler.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/ProofTokenMessageHandler.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using Duende.IdentityModel.Client;
+
 namespace Duende.IdentityModel.OidcClient.DPoP;
 
 /// <summary>
@@ -39,6 +41,15 @@ public class ProofTokenMessageHandler : DelegatingHandler
             {
                 response.Dispose();
 
+                // If a ClientAssertionFactory was stored on the request
+                // options, invoke it now to get a fresh assertion (new jti/iat)
+                // for the retry attempt — servers that enforce assertion
+                // uniqueness reject retries that reuse the same assertion JWT.
+                if (request.Options.TryGetValue(ProtocolRequestOptions.ClientAssertionFactory, out var factory) && factory != null)
+                {
+                    await RefreshClientAssertionAsync(request, factory).ConfigureAwait(false);
+                }
+
                 CreateProofToken(request);
 
                 response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -46,6 +57,36 @@ public class ProofTokenMessageHandler : DelegatingHandler
         }
 
         return response;
+    }
+
+    /// <summary>
+    /// Replaces the <c>client_assertion</c> and <c>client_assertion_type</c> form fields
+    /// in the request body with a fresh assertion obtained from <paramref name="factory"/>.
+    /// </summary>
+    private static async Task RefreshClientAssertionAsync(HttpRequestMessage request, Func<Task<ClientAssertion>> factory)
+    {
+        var freshAssertion = await factory().ConfigureAwait(false);
+        if (freshAssertion?.Value == null)
+        {
+            return;
+        }
+
+        // Read the existing form body.  FormUrlEncodedContent buffers internally,
+        // so ReadAsStringAsync() is safe to call even after the first send.
+        var body = request.Content != null
+            ? await request.Content.ReadAsStringAsync().ConfigureAwait(false)
+            : string.Empty;
+        var parsed = System.Web.HttpUtility.ParseQueryString(body);
+
+        // Replace client_assertion / client_assertion_type, or append if absent.
+        parsed[OidcConstants.TokenRequest.ClientAssertionType] = freshAssertion.Type;
+        parsed[OidcConstants.TokenRequest.ClientAssertion] = freshAssertion.Value;
+
+        var pairs = parsed.AllKeys
+            .Where(k => k != null)
+            .SelectMany(k => parsed.GetValues(k)!.Select(v => new KeyValuePair<string, string>(k!, v)));
+
+        request.Content = new FormUrlEncodedContent(pairs);
     }
 
     private void CreateProofToken(HttpRequestMessage request)

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
@@ -139,6 +139,7 @@ internal class AuthorizeClient
 
             ClientSecret = _options.ClientSecret,
             ClientAssertion = await _options.GetClientAssertionAsync(),
+            ClientAssertionFactory = _options.GetClientAssertionAsync,
             Parameters = CreateAuthorizeParameters(state, codeChallenge, frontChannelParameters),
         };
 

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/IdentityModel.OidcClient.csproj
@@ -12,7 +12,7 @@
     <PackageReadmePath>README.md</PackageReadmePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Duende.IdentityModel" />
+    <ProjectReference Include="../../../identity-model/src/IdentityModel/IdentityModel.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 </Project>

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/OidcClient.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/OidcClient.cs
@@ -350,6 +350,7 @@ public class OidcClient
             ClientId = Options.ClientId,
             ClientSecret = Options.ClientSecret,
             ClientAssertion = await Options.GetClientAssertionAsync(),
+            ClientAssertionFactory = Options.GetClientAssertionAsync,
             ClientCredentialStyle = Options.TokenClientCredentialStyle,
             RefreshToken = refreshToken,
             Parameters = backChannelParameters,

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/ResponseProcessor.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/ResponseProcessor.cs
@@ -182,6 +182,7 @@ internal class ResponseProcessor
             ClientId = _options.ClientId,
             ClientSecret = _options.ClientSecret,
             ClientAssertion = await _options.GetClientAssertionAsync(),
+            ClientAssertionFactory = _options.GetClientAssertionAsync,
             ClientCredentialStyle = _options.TokenClientCredentialStyle,
 
             Code = code,

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/ProofTokenMessageHandlerTests.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/ProofTokenMessageHandlerTests.cs
@@ -1,0 +1,321 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Net;
+using System.Web;
+using Duende.IdentityModel.Client;
+using Duende.IdentityModel.OidcClient.DPoP;
+
+#nullable enable
+
+namespace Duende.IdentityModel.OidcClient;
+
+/// <summary>
+/// Unit tests for <see cref="ProofTokenMessageHandler"/> focusing on client assertion
+/// refresh behavior during DPoP nonce retries.
+/// </summary>
+public class ProofTokenMessageHandlerTests
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+
+    // A stable DPoP nonce returned on the 401, causing the handler to retry.
+    private const string ServerNonce = "server-issued-nonce";
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Minimal <see cref="IDPoPProofTokenFactory"/> stub — just returns a fixed proof token.
+    /// </summary>
+    private sealed class StubDPoPProofTokenFactory : IDPoPProofTokenFactory
+    {
+        public DPoPProof CreateProofToken(DPoPProofRequest request) =>
+            new DPoPProof { ProofToken = "stub-dpop-proof" };
+    }
+
+    /// <summary>
+    /// Builds a simple form-encoded <see cref="HttpRequestMessage"/> that resembles
+    /// a token endpoint request, optionally including a client assertion, and
+    /// optionally stores a <see cref="ClientAssertionFactory"/> on the request options.
+    /// </summary>
+    private static HttpRequestMessage BuildTokenRequest(
+        string? assertionType,
+        string? assertionValue,
+        Func<Task<ClientAssertion>>? factory = null)
+    {
+        var parameters = new List<KeyValuePair<string, string>>
+        {
+            new("grant_type", "client_credentials"),
+            new("client_id", "test_client"),
+        };
+
+        if (assertionType != null && assertionValue != null)
+        {
+            parameters.Add(new(OidcConstants.TokenRequest.ClientAssertionType, assertionType));
+            parameters.Add(new(OidcConstants.TokenRequest.ClientAssertion, assertionValue));
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://server/connect/token")
+        {
+            Content = new FormUrlEncodedContent(parameters)
+        };
+
+        if (factory != null)
+        {
+            request.Options.Set(ProtocolRequestOptions.ClientAssertionFactory, factory);
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    /// Creates a delegating-handler chain:
+    /// <c>ProofTokenMessageHandler → inner</c>
+    /// where <c>inner</c> is driven by the supplied <paramref name="innerHandler"/>.
+    /// </summary>
+    private static HttpClient BuildClient(HttpMessageHandler innerHandler)
+    {
+        var handler = new ProofTokenMessageHandler(new StubDPoPProofTokenFactory(), innerHandler);
+        return new HttpClient(handler);
+    }
+
+    /// <summary>
+    /// Returns an inner handler that first responds with a 401 carrying a
+    /// <c>DPoP-Nonce</c> header, then responds with a 200 on the retry.
+    /// The captured body of the retry request is stored in <paramref name="retryBody"/>.
+    /// </summary>
+    private static HttpMessageHandler MakeNonceRequiredHandler(out Func<string?> retryBody)
+    {
+        string? capturedBody = null;
+        retryBody = () => capturedBody;
+
+        var callCount = 0;
+        return new CallbackHandler(async request =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                // First call: respond 401 + DPoP-Nonce header so the handler retries.
+                var r = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                r.Headers.Add(OidcConstants.HttpHeaders.DPoPNonce, ServerNonce);
+                return r;
+            }
+
+            // Second call (retry): capture the body and return 200.
+            capturedBody = request.Content != null
+                ? await request.Content.ReadAsStringAsync()
+                : null;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"access_token\":\"at\",\"token_type\":\"DPoP\",\"expires_in\":3600}")
+            };
+        });
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task When_factory_set_and_nonce_required_retry_uses_fresh_client_assertion()
+    {
+        var factoryCallCount = 0;
+        Func<Task<ClientAssertion>> factory = () =>
+        {
+            factoryCallCount++;
+            return Task.FromResult(new ClientAssertion
+            {
+                Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                Value = $"fresh_jwt_{factoryCallCount}"
+            });
+        };
+
+        var inner = MakeNonceRequiredHandler(out var getRetryBody);
+        using var client = BuildClient(inner);
+
+        using var request = BuildTokenRequest(
+            assertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            assertionValue: "original_jwt",
+            factory: factory);
+
+        var response = await client.SendAsync(request, _ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // The factory should have been called exactly once (on the retry).
+        factoryCallCount.ShouldBe(1);
+
+        // The retry body should contain the fresh assertion, not the original one.
+        var retryFields = HttpUtility.ParseQueryString(getRetryBody()!);
+        retryFields[OidcConstants.TokenRequest.ClientAssertion].ShouldBe("fresh_jwt_1");
+        retryFields[OidcConstants.TokenRequest.ClientAssertionType]
+            .ShouldBe("urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+    }
+
+    [Fact]
+    public async Task When_factory_set_and_nonce_required_original_assertion_is_not_reused()
+    {
+        Func<Task<ClientAssertion>> factory = () => Task.FromResult(new ClientAssertion
+        {
+            Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            Value = "fresh_jwt"
+        });
+
+        var inner = MakeNonceRequiredHandler(out var getRetryBody);
+        using var client = BuildClient(inner);
+
+        using var request = BuildTokenRequest(
+            assertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            assertionValue: "original_jwt",
+            factory: factory);
+
+        await client.SendAsync(request, _ct);
+
+        // The retry must NOT contain the original JWT.
+        var retryFields = HttpUtility.ParseQueryString(getRetryBody()!);
+        retryFields[OidcConstants.TokenRequest.ClientAssertion].ShouldNotBe("original_jwt");
+    }
+
+    [Fact]
+    public async Task When_no_factory_and_nonce_required_retry_reuses_original_body_unchanged()
+    {
+        // Backward-compatibility: if no factory is present the handler retries without
+        // touching the form body (same behaviour as before this fix was introduced).
+        var inner = MakeNonceRequiredHandler(out var getRetryBody);
+        using var client = BuildClient(inner);
+
+        using var request = BuildTokenRequest(
+            assertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            assertionValue: "original_jwt",
+            factory: null);   // ← no factory
+
+        var response = await client.SendAsync(request, _ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Body on retry should still have the original assertion value.
+        var retryFields = HttpUtility.ParseQueryString(getRetryBody()!);
+        retryFields[OidcConstants.TokenRequest.ClientAssertion].ShouldBe("original_jwt");
+    }
+
+    [Fact]
+    public async Task When_factory_set_and_no_nonce_required_factory_is_not_invoked()
+    {
+        // If the server does not return a DPoP nonce there is no retry, so the factory
+        // must not be called.
+        var factoryCallCount = 0;
+        Func<Task<ClientAssertion>> factory = () =>
+        {
+            factoryCallCount++;
+            return Task.FromResult(new ClientAssertion
+            {
+                Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                Value = "fresh_jwt"
+            });
+        };
+
+        // Inner handler returns success on first call (no nonce header).
+        var inner = new CallbackHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"access_token\":\"at\",\"token_type\":\"DPoP\",\"expires_in\":3600}")
+        }));
+
+        using var client = BuildClient(inner);
+        using var request = BuildTokenRequest(
+            assertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            assertionValue: "original_jwt",
+            factory: factory);
+
+        await client.SendAsync(request, _ct);
+
+        factoryCallCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task When_factory_returns_null_value_body_is_not_modified()
+    {
+        // If the factory returns a ClientAssertion with a null Value the handler should
+        // leave the form body as-is (defensive fallback).
+        Func<Task<ClientAssertion>> factory = () =>
+            Task.FromResult<ClientAssertion>(new ClientAssertion { Value = null! });
+
+        var inner = MakeNonceRequiredHandler(out var getRetryBody);
+        using var client = BuildClient(inner);
+
+        using var request = BuildTokenRequest(
+            assertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            assertionValue: "original_jwt",
+            factory: factory);
+
+        var response = await client.SendAsync(request, _ct);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // Body should be unchanged when factory returns a null value.
+        var retryFields = HttpUtility.ParseQueryString(getRetryBody()!);
+        retryFields[OidcConstants.TokenRequest.ClientAssertion].ShouldBe("original_jwt");
+    }
+
+    [Fact]
+    public async Task When_factory_set_duplicate_form_keys_are_preserved()
+    {
+        // Requests with multiple "resource" (or other) parameters must not lose values
+        // when the body is re-built after refreshing the client assertion.
+        Func<Task<ClientAssertion>> factory = () => Task.FromResult(new ClientAssertion
+        {
+            Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            Value = "fresh_jwt"
+        });
+
+        var inner = MakeNonceRequiredHandler(out var getRetryBody);
+        using var client = BuildClient(inner);
+
+        // Manually build a request body with duplicate "resource" keys.
+        var pairs = new List<KeyValuePair<string, string>>
+        {
+            new("grant_type", "client_credentials"),
+            new("client_id", "test_client"),
+            new("resource", "urn:resource:a"),
+            new("resource", "urn:resource:b"),
+            new(OidcConstants.TokenRequest.ClientAssertionType, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"),
+            new(OidcConstants.TokenRequest.ClientAssertion, "original_jwt"),
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://server/connect/token")
+        {
+            Content = new FormUrlEncodedContent(pairs)
+        };
+        request.Options.Set(ProtocolRequestOptions.ClientAssertionFactory, factory);
+
+        await client.SendAsync(request, _ct);
+
+        // Rebuild as NameValueCollection (same as the handler does internally via
+        // HttpUtility.ParseQueryString) to check multi-values.
+        var retryFields = HttpUtility.ParseQueryString(getRetryBody()!);
+        var resourceValues = retryFields.GetValues("resource");
+        resourceValues.ShouldNotBeNull();
+        resourceValues.ShouldContain("urn:resource:a");
+        resourceValues.ShouldContain("urn:resource:b");
+
+        // And the assertion should be refreshed.
+        retryFields[OidcConstants.TokenRequest.ClientAssertion].ShouldBe("fresh_jwt");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Private helper: a simple delegate-based HttpMessageHandler
+    // ---------------------------------------------------------------------------
+
+    private sealed class CallbackHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _callback;
+
+        public CallbackHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> callback) =>
+            _callback = callback;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            _callback(request);
+    }
+}

--- a/identity-model/samples/ClientAssertions/ClientAssertionService.cs
+++ b/identity-model/samples/ClientAssertions/ClientAssertionService.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+public class ClientAssertionService
+{
+    private static string RsaKey =
+        """
+        {
+            "d":"GmiaucNIzdvsEzGjZjd43SDToy1pz-Ph-shsOUXXh-dsYNGftITGerp8bO1iryXh_zUEo8oDK3r1y4klTonQ6bLsWw4ogjLPmL3yiqsoSjJa1G2Ymh_RY_sFZLLXAcrmpbzdWIAkgkHSZTaliL6g57vA7gxvd8L4s82wgGer_JmURI0ECbaCg98JVS0Srtf9GeTRHoX4foLWKc1Vq6NHthzqRMLZe-aRBNU9IMvXNd7kCcIbHCM3GTD_8cFj135nBPP2HOgC_ZXI1txsEf-djqJj8W5vaM7ViKU28IDv1gZGH3CatoysYx6jv1XJVvb2PH8RbFKbJmeyUm3Wvo-rgQ",
+            "dp":"YNjVBTCIwZD65WCht5ve06vnBLP_Po1NtL_4lkholmPzJ5jbLYBU8f5foNp8DVJBdFQW7wcLmx85-NC5Pl1ZeyA-Ecbw4fDraa5Z4wUKlF0LT6VV79rfOF19y8kwf6MigyrDqMLcH_CRnRGg5NfDsijlZXffINGuxg6wWzhiqqE",
+            "dq":"LfMDQbvTFNngkZjKkN2CBh5_MBG6Yrmfy4kWA8IC2HQqID5FtreiY2MTAwoDcoINfh3S5CItpuq94tlB2t-VUv8wunhbngHiB5xUprwGAAnwJ3DL39D2m43i_3YP-UO1TgZQUAOh7Jrd4foatpatTvBtY3F1DrCrUKE5Kkn770M",
+            "e":"AQAB",
+            "kid":"ZzAjSnraU3bkWGnnAqLapYGpTyNfLbjbzgAPbbW2GEA",
+            "kty":"RSA",
+            "n":"wWwQFtSzeRjjerpEM5Rmqz_DsNaZ9S1Bw6UbZkDLowuuTCjBWUax0vBMMxdy6XjEEK4Oq9lKMvx9JzjmeJf1knoqSNrox3Ka0rnxXpNAz6sATvme8p9mTXyp0cX4lF4U2J54xa2_S9NF5QWvpXvBeC4GAJx7QaSw4zrUkrc6XyaAiFnLhQEwKJCwUw4NOqIuYvYp_IXhw-5Ti_icDlZS-282PcccnBeOcX7vc21pozibIdmZJKqXNsL1Ibx5Nkx1F1jLnekJAmdaACDjYRLL_6n3W4wUp19UvzB1lGtXcJKLLkqB6YDiZNu16OSiSprfmrRXvYmvD8m6Fnl5aetgKw",
+            "p":"7enorp9Pm9XSHaCvQyENcvdU99WCPbnp8vc0KnY_0g9UdX4ZDH07JwKu6DQEwfmUA1qspC-e_KFWTl3x0-I2eJRnHjLOoLrTjrVSBRhBMGEH5PvtZTTThnIY2LReH-6EhceGvcsJ_MhNDUEZLykiH1OnKhmRuvSdhi8oiETqtPE",
+            "q":"0CBLGi_kRPLqI8yfVkpBbA9zkCAshgrWWn9hsq6a7Zl2LcLaLBRUxH0q1jWnXgeJh9o5v8sYGXwhbrmuypw7kJ0uA3OgEzSsNvX5Ay3R9sNel-3Mqm8Me5OfWWvmTEBOci8RwHstdR-7b9ZT13jk-dsZI7OlV_uBja1ny9Nz9ts",
+            "qi":"pG6J4dcUDrDndMxa-ee1yG4KjZqqyCQcmPAfqklI2LmnpRIjcK78scclvpboI3JQyg6RCEKVMwAhVtQM6cBcIO3JrHgqeYDblp5wXHjto70HVW6Z8kBruNx1AH9E8LzNvSRL-JVTFzBkJuNgzKQfD0G77tQRgJ-Ri7qu3_9o1M4"
+        }
+        """;
+
+    private static SigningCredentials Credential = new(new JsonWebKey(RsaKey), "RS256");
+
+    public static Task<ClientAssertion> Create(CancellationToken ct = default)
+    {
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = "m2m.jwt",
+
+            // Don't use the TokenEndpoint here. Use the Authority as the audience.
+            // You may expose yourself to a vulnerability, as described in the document below:
+            // https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf
+            Audience = "https://demo.duendesoftware.com",
+            Expires = DateTime.UtcNow.AddMinutes(1),
+            SigningCredentials = Credential,
+
+            Claims = new Dictionary<string, object>
+            {
+                { JwtClaimTypes.JwtId, Guid.NewGuid().ToString() },
+                { JwtClaimTypes.Subject, "m2m.jwt" },
+                { JwtClaimTypes.IssuedAt, DateTimeOffset.UtcNow.ToUnixTimeSeconds() }
+            },
+
+            AdditionalHeaderClaims = new Dictionary<string, object>
+            {
+                { JwtClaimTypes.TokenType, "client-authentication+jwt" }
+            }
+        };
+
+        var handler = new JsonWebTokenHandler();
+        var jwt = handler.CreateToken(descriptor);
+
+        return Task.FromResult(new ClientAssertion
+        {
+            Type = OidcConstants.ClientAssertionTypes.JwtBearer,
+            Value = jwt
+        });
+    }
+}

--- a/identity-model/samples/ClientAssertions/ClientAssertions.csproj
+++ b/identity-model/samples/ClientAssertions/ClientAssertions.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\IdentityModel\IdentityModel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.16.0" />
+    <PackageReference Include="Duende.IdentityModel" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/identity-model/samples/ClientAssertions/Program.cs
+++ b/identity-model/samples/ClientAssertions/Program.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Duende.IdentityModel.Client;
+
+
+
+var disco = await GetDiscoveryDocument();
+
+// HttpClient Extensions style
+Console.WriteLine("Requesting tokens using HttpClient Extension Method");
+var http = new HttpClient();
+var response = await http.RequestClientCredentialsTokenAsync(new ClientCredentialsTokenRequest()
+{
+    Address = disco.TokenEndpoint ?? throw new InvalidOperationException("No token endpoint found in discovery document"),
+    ClientId = "m2m.jwt",
+    ClientAssertion = await ClientAssertionService.Create(),
+    ClientAssertionFactory = async () => await ClientAssertionService.Create(),
+    ClientCredentialStyle = ClientCredentialStyle.PostBody
+});
+Display(response);
+
+
+async Task<DiscoveryDocumentResponse> GetDiscoveryDocument()
+{
+    var http = new HttpClient()
+    {
+        BaseAddress = new Uri("https://demo.duendesoftware.com")
+    };
+    var disco = await http.GetDiscoveryDocumentAsync();
+    if (disco.IsError)
+    {
+        Console.WriteLine("Discovery failure: " + disco.Error);
+        Environment.Exit(-1);
+    }
+    return disco;
+}
+
+void Display(TokenResponse tokenResponse)
+{
+    if (tokenResponse.IsError)
+    {
+        Console.WriteLine($"{tokenResponse.Error} - {tokenResponse.ErrorDescription}");
+    }
+    else
+    {
+        Console.WriteLine("Access Token received:");
+        Console.WriteLine(tokenResponse.AccessToken);
+        Console.WriteLine();
+    }
+}

--- a/identity-model/src/IdentityModel/Client/HttpClientPushedAuthorizationExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientPushedAuthorizationExtensions.cs
@@ -66,6 +66,15 @@ public static class HttpClientPushedAuthorizationExtensions
 
     internal static async Task<PushedAuthorizationResponse> PushAuthorizationAsync(this HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken = default)
     {
+        // If a factory is set, invoke it to get a fresh assertion for this attempt and
+        // store it on Options so that DPoP retry handlers can invoke it again on each
+        // subsequent attempt. The factory always takes precedence over a static ClientAssertion.
+        if (request.ClientAssertionFactory != null)
+        {
+            request.ClientAssertion = await request.ClientAssertionFactory().ConfigureAwait();
+            request.Options.TryAdd(ProtocolRequestOptions.ClientAssertionFactory.Key, request.ClientAssertionFactory);
+        }
+
         request.Prepare();
         request.Method = HttpMethod.Post;
 

--- a/identity-model/src/IdentityModel/Client/HttpClientTokenRequestExtensions.cs
+++ b/identity-model/src/IdentityModel/Client/HttpClientTokenRequestExtensions.cs
@@ -213,6 +213,15 @@ public static class HttpClientTokenRequestExtensions
 
     internal static async Task<TokenResponse> RequestTokenAsync(this HttpMessageInvoker client, ProtocolRequest request, CancellationToken cancellationToken = default)
     {
+        // If a factory is set, invoke it to get a fresh assertion for this attempt and
+        // store it on Options so that DPoP retry handlers can invoke it again on each
+        // subsequent attempt. The factory always takes precedence over a static ClientAssertion.
+        if (request.ClientAssertionFactory != null)
+        {
+            request.ClientAssertion = await request.ClientAssertionFactory().ConfigureAwait();
+            request.Options.TryAdd(ProtocolRequestOptions.ClientAssertionFactory.Key, request.ClientAssertionFactory);
+        }
+
         request.Prepare();
         request.Method = HttpMethod.Post;
 

--- a/identity-model/src/IdentityModel/Client/Messages/ProtocolRequest.cs
+++ b/identity-model/src/IdentityModel/Client/Messages/ProtocolRequest.cs
@@ -7,6 +7,21 @@ using Duende.IdentityModel.Internal;
 namespace Duende.IdentityModel.Client;
 
 /// <summary>
+/// Well-known <see cref="HttpRequestOptionsKey{TValue}"/> keys used by Duende IdentityModel
+/// when passing data through handler chains.
+/// </summary>
+public static class ProtocolRequestOptions
+{
+    /// <summary>
+    /// The key used to store a <see cref="ClientAssertionFactory"/> on
+    /// <see cref="HttpRequestMessage.Options"/>.  DPoP retry handlers read this key to obtain
+    /// a fresh <see cref="ClientAssertion"/> for each attempt.
+    /// </summary>
+    public static readonly HttpRequestOptionsKey<Func<Task<ClientAssertion>>?> ClientAssertionFactory =
+        new HttpRequestOptionsKey<Func<Task<ClientAssertion>>?>("Duende.IdentityModel.ClientAssertionFactory");
+}
+
+/// <summary>
 /// Models a base OAuth/OIDC request with client credentials
 /// </summary>
 public class ProtocolRequest : HttpRequestMessage
@@ -74,6 +89,14 @@ public class ProtocolRequest : HttpRequestMessage
     public string? DPoPProofToken { get; set; }
 
     /// <summary>
+    /// Gets or sets a factory function that creates a fresh <see cref="ClientAssertion"/> on demand.
+    /// When set, this factory is stored on <see cref="HttpRequestMessage.Options"/> so that DPoP retry
+    /// handlers can invoke it to obtain a new assertion (with a fresh <c>jti</c> and <c>iat</c>) on
+    /// each attempt, avoiding client-assertion replay rejected by servers that enforce uniqueness.
+    /// </summary>
+    public Func<Task<ClientAssertion>>? ClientAssertionFactory { get; set; }
+
+    /// <summary>
     /// Gets or sets additional protocol parameters.
     /// </summary>
     /// <value>
@@ -101,6 +124,7 @@ public class ProtocolRequest : HttpRequestMessage
             Address = Address,
             AuthorizationHeaderStyle = AuthorizationHeaderStyle,
             ClientAssertion = ClientAssertion,
+            ClientAssertionFactory = ClientAssertionFactory,
             ClientCredentialStyle = ClientCredentialStyle,
             ClientId = ClientId,
             ClientSecret = ClientSecret,

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/PushedAuthorizationTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/PushedAuthorizationTests.cs
@@ -213,4 +213,84 @@ public class PushedAuthorizationTests
         var exception = await act.ShouldThrowAsync<ArgumentException>();
         exception.ParamName.ShouldBe("request_uri");
     }
+
+    [Fact]
+    public async Task Setting_only_client_assertion_factory_should_invoke_factory_and_send_assertion()
+    {
+        var document = File.ReadAllText(FileName.Create("success_par_response.json"));
+        var handler = new NetworkHandler(document, HttpStatusCode.OK);
+        var client = new HttpClient(handler);
+
+        var response = await client.PushAuthorizationAsync(new PushedAuthorizationRequest
+        {
+            ClientId = "client",
+            ResponseType = "code",
+            Address = Endpoint,
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+            ClientAssertionFactory = () => Task.FromResult(new ClientAssertion
+            {
+                Type = "factory_type",
+                Value = "factory_value"
+            })
+        }, _ct);
+
+        var fields = QueryHelpers.ParseQuery(handler.Body);
+
+        fields["client_assertion_type"].First().ShouldBe("factory_type");
+        fields["client_assertion"].First().ShouldBe("factory_value");
+    }
+
+    [Fact]
+    public async Task Setting_only_client_assertion_factory_should_store_factory_in_options()
+    {
+        var document = File.ReadAllText(FileName.Create("success_par_response.json"));
+        var handler = new NetworkHandler(document, HttpStatusCode.OK);
+        var client = new HttpClient(handler);
+
+        var factory = new Func<Task<ClientAssertion>>(() => Task.FromResult(new ClientAssertion
+        {
+            Type = "factory_type",
+            Value = "factory_value"
+        }));
+
+        await client.PushAuthorizationAsync(new PushedAuthorizationRequest
+        {
+            ClientId = "client",
+            ResponseType = "code",
+            Address = Endpoint,
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+            ClientAssertionFactory = factory
+        }, _ct);
+
+        handler.Request.Options.TryGetValue(ProtocolRequestOptions.ClientAssertionFactory, out var storedFactory)
+            .ShouldBeTrue();
+        storedFactory.ShouldBeSameAs(factory);
+    }
+
+    [Fact]
+    public async Task Client_assertion_factory_should_take_precedence_over_static_client_assertion()
+    {
+        var document = File.ReadAllText(FileName.Create("success_par_response.json"));
+        var handler = new NetworkHandler(document, HttpStatusCode.OK);
+        var client = new HttpClient(handler);
+
+        await client.PushAuthorizationAsync(new PushedAuthorizationRequest
+        {
+            ClientId = "client",
+            ResponseType = "code",
+            Address = Endpoint,
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+            ClientAssertion = { Type = "static_type", Value = "static_value" },
+            ClientAssertionFactory = () => Task.FromResult(new ClientAssertion
+            {
+                Type = "factory_type",
+                Value = "factory_value"
+            })
+        }, _ct);
+
+        var fields = QueryHelpers.ParseQuery(handler.Body);
+
+        fields["client_assertion_type"].First().ShouldBe("factory_type");
+        fields["client_assertion"].First().ShouldBe("factory_value");
+    }
 }

--- a/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
+++ b/identity-model/test/IdentityModel.Tests/HttpClientExtensions/TokenRequestExtensionsRequestTests.cs
@@ -718,4 +718,66 @@ public class TokenRequestExtensionsRequestTests
         fields["client_assertion_type"].First().ShouldBe("type");
         fields["client_assertion"].First().ShouldBe("value");
     }
+
+    [Fact]
+    public async Task Setting_only_client_assertion_factory_should_invoke_factory_and_send_assertion()
+    {
+        var response = await _client.RequestTokenAsync(new TokenRequest
+        {
+            GrantType = "test",
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+            ClientAssertionFactory = () => Task.FromResult(new ClientAssertion
+            {
+                Type = "factory_type",
+                Value = "factory_value"
+            })
+        }, _ct);
+
+        var fields = QueryHelpers.ParseQuery(_handler.Body);
+
+        fields["client_assertion_type"].First().ShouldBe("factory_type");
+        fields["client_assertion"].First().ShouldBe("factory_value");
+    }
+
+    [Fact]
+    public async Task Setting_only_client_assertion_factory_should_store_factory_in_options()
+    {
+        var factory = new Func<Task<ClientAssertion>>(() => Task.FromResult(new ClientAssertion
+        {
+            Type = "factory_type",
+            Value = "factory_value"
+        }));
+
+        var response = await _client.RequestTokenAsync(new TokenRequest
+        {
+            GrantType = "test",
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+            ClientAssertionFactory = factory
+        }, _ct);
+
+        _handler.Request.Options.TryGetValue(ProtocolRequestOptions.ClientAssertionFactory, out var storedFactory)
+            .ShouldBeTrue();
+        storedFactory.ShouldBeSameAs(factory);
+    }
+
+    [Fact]
+    public async Task Client_assertion_factory_should_take_precedence_over_static_client_assertion()
+    {
+        var response = await _client.RequestTokenAsync(new TokenRequest
+        {
+            GrantType = "test",
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+            ClientAssertion = { Type = "static_type", Value = "static_value" },
+            ClientAssertionFactory = () => Task.FromResult(new ClientAssertion
+            {
+                Type = "factory_type",
+                Value = "factory_value"
+            })
+        }, _ct);
+
+        var fields = QueryHelpers.ParseQuery(_handler.Body);
+
+        fields["client_assertion_type"].First().ShouldBe("factory_type");
+        fields["client_assertion"].First().ShouldBe("factory_value");
+    }
 }

--- a/identity-model/test/IdentityModel.Tests/ProtocolRequestTests.cs
+++ b/identity-model/test/IdentityModel.Tests/ProtocolRequestTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Duende.IdentityModel.Client;
+
+namespace Duende.IdentityModel;
+
+public class ProtocolRequestTests
+{
+    [Fact]
+    public void Clone_preserves_ClientAssertionFactory()
+    {
+        Func<Task<ClientAssertion>> factory = () => Task.FromResult(new ClientAssertion
+        {
+            Type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            Value = "factory_jwt"
+        });
+
+        var original = new ProtocolRequest
+        {
+            ClientId = "client1",
+            ClientAssertionFactory = factory
+        };
+
+        var clone = original.Clone();
+
+        clone.ClientAssertionFactory.ShouldBeSameAs(factory);
+    }
+
+    [Fact]
+    public void Clone_with_null_factory_leaves_factory_null()
+    {
+        var original = new ProtocolRequest
+        {
+            ClientId = "client1",
+            ClientAssertionFactory = null
+        };
+
+        var clone = original.Clone();
+
+        clone.ClientAssertionFactory.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Clone_copies_standard_properties()
+    {
+        var original = new ProtocolRequest
+        {
+            Address = "https://server/token",
+            ClientId = "client1",
+            ClientSecret = "secret",
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+        };
+        original.Parameters.Add("custom", "value");
+
+        var clone = original.Clone();
+
+        clone.Address.ShouldBe(original.Address);
+        clone.ClientId.ShouldBe(original.ClientId);
+        clone.ClientSecret.ShouldBe(original.ClientSecret);
+        clone.ClientCredentialStyle.ShouldBe(original.ClientCredentialStyle);
+        clone.Parameters.ShouldContain(p => p.Key == "custom" && p.Value == "value");
+    }
+}

--- a/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/identity-model/test/IdentityModel.Tests/Verifications/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -1159,6 +1159,7 @@ namespace Duende.IdentityModel.Client
         public string? Address { get; set; }
         public Duende.IdentityModel.Client.BasicAuthenticationHeaderStyle AuthorizationHeaderStyle { get; set; }
         public Duende.IdentityModel.Client.ClientAssertion ClientAssertion { get; set; }
+        public System.Func<System.Threading.Tasks.Task<Duende.IdentityModel.Client.ClientAssertion>>? ClientAssertionFactory { get; set; }
         public Duende.IdentityModel.Client.ClientCredentialStyle ClientCredentialStyle { get; set; }
         public string ClientId { get; set; }
         public string? ClientSecret { get; set; }
@@ -1168,6 +1169,10 @@ namespace Duende.IdentityModel.Client
         public T Clone<T>()
             where T : Duende.IdentityModel.Client.ProtocolRequest, new () { }
         public void Prepare() { }
+    }
+    public static class ProtocolRequestOptions
+    {
+        public static readonly System.Net.Http.HttpRequestOptionsKey<System.Func<System.Threading.Tasks.Task<Duende.IdentityModel.Client.ClientAssertion>>?> ClientAssertionFactory;
     }
     public class ProtocolResponse : System.IDisposable
     {


### PR DESCRIPTION
This allows for DPoP retries to obtain a fresh client assertion, which
is required when the AS uses nonces and rejects reused assertions.