### PR TITLE
Remove setup-dotnet from release publish jobs

### DIFF
--- a/.github/workflow-gen/Program.cs
+++ b/.github/workflow-gen/Program.cs
@@ -237,8 +237,6 @@ git push origin {component.TagPrefix}-{contexts.Event.Input.Version}");
         .Uses("actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16") // 4.1.8
         .With(("name", "artifacts"), ("path", "artifacts"));
 
-    publishJob.StepSetupDotNet();
-
     publishJob.Step()
         .Name("List files")
         .Shell("bash")

--- a/.github/workflows/access-token-management-release.yml
+++ b/.github/workflows/access-token-management-release.yml
@@ -99,10 +99,6 @@ jobs:
       with:
         name: artifacts
         path: artifacts
-    - name: Setup .NET
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
-      with:
-        global-json-file: global.json
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/identity-model-oidc-client-release.yml
+++ b/.github/workflows/identity-model-oidc-client-release.yml
@@ -99,10 +99,6 @@ jobs:
       with:
         name: artifacts
         path: artifacts
-    - name: Setup .NET
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
-      with:
-        global-json-file: global.json
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/identity-model-release.yml
+++ b/.github/workflows/identity-model-release.yml
@@ -97,10 +97,6 @@ jobs:
       with:
         name: artifacts
         path: artifacts
-    - name: Setup .NET
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
-      with:
-        global-json-file: global.json
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/ignore-this-release.yml
+++ b/.github/workflows/ignore-this-release.yml
@@ -97,10 +97,6 @@ jobs:
       with:
         name: artifacts
         path: artifacts
-    - name: Setup .NET
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
-      with:
-        global-json-file: global.json
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/introspection-release.yml
+++ b/.github/workflows/introspection-release.yml
@@ -97,10 +97,6 @@ jobs:
       with:
         name: artifacts
         path: artifacts
-    - name: Setup .NET
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
-      with:
-        global-json-file: global.json
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/memory-cache-release.yml
+++ b/.github/workflows/memory-cache-release.yml
@@ -97,10 +97,6 @@ jobs:
       with:
         name: artifacts
         path: artifacts
-    - name: Setup .NET
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
-      with:
-        global-json-file: global.json
     - name: List files
       run: tree
       shell: bash

--- a/.github/workflows/razor-slices-release.yml
+++ b/.github/workflows/razor-slices-release.yml
@@ -97,10 +97,6 @@ jobs:
       with:
         name: artifacts
         path: artifacts
-    - name: Setup .NET
-      uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
-      with:
-        global-json-file: global.json
     - name: List files
       run: tree
       shell: bash


### PR DESCRIPTION
## Summary

- The publish job in release workflows was failing because `setup-dotnet` referenced `global.json`, which doesn't exist since the repo isn't checked out in that job.
- Removed the `setup-dotnet` step from publish jobs — they only run `dotnet nuget push`, which works with the pre-installed SDK on the GitHub runner.
- Updated the workflow generator and regenerated all 7 release workflow files.

Fixes the failure seen in https://github.com/DuendeSoftware/foss/actions/runs/23018061224/job/66846781041