### PR TITLE
Allow ClientAssertions with PAR

### DIFF
--- a/access-token-management/samples/WebClientAssertions/Controllers/HomeController.cs
+++ b/access-token-management/samples/WebClientAssertions/Controllers/HomeController.cs
@@ -3,8 +3,8 @@
 
 using System.Text.Json;
 using Duende.AccessTokenManagement;
+using Duende.AccessTokenManagement.DPoP;
 using Duende.AccessTokenManagement.OpenIdConnect;
-using Duende.IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -15,11 +15,13 @@ public class HomeController : Controller
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IUserTokenManager _tokenManager;
+    private readonly IDPoPProofService _dPoPProofService;
 
-    public HomeController(IHttpClientFactory httpClientFactory, IUserTokenManager tokenManager)
+    public HomeController(IHttpClientFactory httpClientFactory, IUserTokenManager tokenManager, IDPoPProofService dPoPProofService)
     {
         _httpClientFactory = httpClientFactory;
         _tokenManager = tokenManager;
+        _dPoPProofService = dPoPProofService;
     }
 
     [AllowAnonymous]
@@ -39,11 +41,33 @@ public class HomeController : Controller
     public async Task<IActionResult> CallApiAsUserManual()
     {
         var token = await _tokenManager.GetAccessTokenAsync(User).GetToken();
-        var client = _httpClientFactory.CreateClient();
-        client.SetBearerToken(token.AccessToken.ToString()!);
 
-        var response = await client.GetStringAsync("https://demo.duendesoftware.com/api/dpop/test");
-        ViewBag.Json = PrettyPrint(response);
+        var url = new Uri("https://demo.duendesoftware.com/api/dpop/test");
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new ("DPoP", token.AccessToken.ToString());
+
+        if (token.DPoPJsonWebKey is { } key)
+        {
+            var proof = await _dPoPProofService.CreateProofTokenAsync(new DPoPProofRequest
+            {
+                Url = url,
+                Method = HttpMethod.Get,
+                DPoPProofKey = key,
+                AccessToken = token.AccessToken,
+            });
+
+            if (proof is not null)
+            {
+                request.SetDPoPProofToken(proof.Value);
+            }
+        }
+
+        var client = _httpClientFactory.CreateClient();
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        ViewBag.Json = PrettyPrint(json);
 
         return View("CallApi");
     }

--- a/access-token-management/samples/WebClientAssertions/Startup.cs
+++ b/access-token-management/samples/WebClientAssertions/Startup.cs
@@ -86,7 +86,7 @@ public static class Startup
         // Register our client assertion service (replaces the default no-op)
         builder.Services.AddTransient<IClientAssertionService, ClientAssertionService>();
 
-        // --- Named M2M client (client credentials with JWT auth, no DPoP) ---
+        // --- Named M2M client (client credentials with JWT auth + DPoP) ---
         builder.Services.AddClientCredentialsTokenManagement()
             .AddClient("m2m.jwt", client =>
             {
@@ -94,6 +94,7 @@ public static class Startup
                 client.ClientId = ClientId.Parse("m2m.jwt");
                 // No ClientSecret — assertion service provides credentials
                 client.Scope = Scope.Parse("api");
+                client.DPoPJsonWebKey = DPoPProofKey.Parse(dpopJwk);
             });
 
         // --- HTTP Clients ---
@@ -111,17 +112,17 @@ public static class Startup
             })
             .AddUserAccessTokenHandler();
 
-        // Client access token clients (M2M with JWT assertion, no DPoP)
+        // Client access token clients (M2M with JWT assertion + DPoP)
         builder.Services.AddClientCredentialsHttpClient("client",
             ClientCredentialsClientName.Parse("m2m.jwt"),
             client =>
             {
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/");
+                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
             });
 
         builder.Services.AddHttpClient<TypedClientClient>(client =>
             {
-                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/");
+                client.BaseAddress = new Uri("https://demo.duendesoftware.com/api/dpop/");
             })
             .AddClientCredentialsTokenHandler(ClientCredentialsClientName.Parse("m2m.jwt"));
 

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/ConfigureOpenIdConnectOptions.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/ConfigureOpenIdConnectOptions.cs
@@ -59,6 +59,7 @@ internal class ConfigureOpenIdConnectOptions(
             options.Events.OnRedirectToIdentityProvider = CreateCallback(options.Events.OnRedirectToIdentityProvider);
             options.Events.OnAuthorizationCodeReceived = CreateCallback(options.Events.OnAuthorizationCodeReceived);
             options.Events.OnTokenValidated = CreateCallback(options.Events.OnTokenValidated);
+            options.Events.OnPushAuthorization = CreateCallback(options.Events.OnPushAuthorization);
 
             options.BackchannelHttpHandler = new AuthorizationServerDPoPHandler(dPoPProofService, dPoPNonceStore, httpContextAccessor, loggerFactory)
             {
@@ -149,6 +150,42 @@ internal class ConfigureOpenIdConnectOptions(
             //    // and defer to the host and/or IUserTokenStore implementation to decide where the key is kept
             //    //context.Properties!.RemoveProofKey();
             //}
+        }
+
+        return Callback;
+    }
+
+    private Func<PushedAuthorizationContext, Task> CreateCallback(Func<PushedAuthorizationContext, Task> inner)
+    {
+        async Task Callback(PushedAuthorizationContext context)
+        {
+            await inner.Invoke(context);
+
+            // --- DPoP thumbprint ---
+            var dPoPKeyStore = context.HttpContext.RequestServices.GetRequiredService<IDPoPKeyStore>();
+            var key = await dPoPKeyStore.GetKeyAsync(ClientName);
+            if (key != null)
+            {
+                var jkt = dPoPProofService.GetProofKeyThumbprint(key.Value);
+                if (jkt != null)
+                {
+                    context.Properties.SetProofKey(key.Value);
+                    context.ProtocolMessage.Parameters[OidcConstants.AuthorizeRequest.DPoPKeyThumbprint] =
+                        jkt.ToString();
+                }
+            }
+
+            // --- Client assertion ---
+            var assertion = await clientAssertionService
+                .GetClientAssertionAsync(ClientName, ct: context.HttpContext.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (assertion != null)
+            {
+                context.ProtocolMessage.ClientAssertionType = assertion.Type;
+                context.ProtocolMessage.ClientAssertion = assertion.Value;
+                context.HandleClientAuthentication();
+            }
         }
 
         return Callback;

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/AppHost.cs
@@ -21,6 +21,7 @@ public class AppHost : GenericHost
     public string ClientId;
     public string? ClientSecret;
     public SigningCredentials? ClientAssertionSigningCredentials { get; set; }
+    public PushedAuthorizationBehavior PushedAuthorizationBehavior { get; set; } = PushedAuthorizationBehavior.Disable;
 
     private readonly IdentityServerHost _identityServerHost;
     private readonly ApiHost _apiHost;
@@ -107,27 +108,13 @@ public class AppHost : GenericHost
                 }
 
                 options.ProtocolValidator.RequireNonce = false;
+                options.PushedAuthorizationBehavior = PushedAuthorizationBehavior;
             });
 
         if (ClientAssertionSigningCredentials is { } assertionCredentials)
         {
             services.AddSingleton<IClientAssertionService>(
                 new JwtClientAssertionService(ClientId, assertionCredentials));
-
-            services.Configure<OpenIdConnectOptions>("oidc", opt =>
-            {
-                opt.Events.OnAuthorizationCodeReceived = async context =>
-                {
-                    var svc = context.HttpContext.RequestServices
-                        .GetRequiredService<IClientAssertionService>();
-                    var assertion = await svc.GetClientAssertionAsync(
-                        ClientCredentialsClientName.Parse(ClientId))
-                        ?? throw new InvalidOperationException("Client assertion is null");
-
-                    context.TokenEndpointRequest!.ClientAssertionType = assertion.Type;
-                    context.TokenEndpointRequest.ClientAssertion = assertion.Value;
-                };
-            });
         }
 
         services.AddOpenIdConnectAccessTokenManagement(opt =>

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/IdentityServerHost.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/IdentityServerHost.cs
@@ -39,8 +39,11 @@ public class IdentityServerHost : GenericHost
         new("urn:api2")
     ];
 
+    public bool EnablePar { get; set; }
+
     public List<Dictionary<string, string>> CapturedTokenRequests { get; } = [];
     public List<Dictionary<string, string>> CapturedRevocationRequests { get; } = [];
+    public List<Dictionary<string, string>> CapturedParRequests { get; } = [];
 
     private void ConfigureServices(IServiceCollection services)
     {
@@ -60,8 +63,8 @@ public class IdentityServerHost : GenericHost
                 options.DPoP.ServerClockSkew = TimeSpan.Zero;
                 options.DPoP.ProofTokenValidityDuration = TimeSpan.FromSeconds(1);
 
-                // Disable PAR (this keeps test setup simple, and we don't need to integration test PAR here - it is covered by IdentityServer itself)
-                options.Endpoints.EnablePushedAuthorizationEndpoint = false;
+                // Disable PAR by default (this keeps test setup simple). Tests that need PAR set EnablePar = true.
+                options.Endpoints.EnablePushedAuthorizationEndpoint = EnablePar;
             })
             .AddInMemoryClients(Clients)
             .AddInMemoryIdentityResources(IdentityResources)
@@ -89,6 +92,14 @@ public class IdentityServerHost : GenericHost
                     kvp => kvp.Key,
                     kvp => kvp.Value.ToString());
                 CapturedRevocationRequests.Add(capturedData);
+            }
+            else if (ctx.Request.Path == "/connect/par" && ctx.Request.Method == "POST")
+            {
+                var form = await ctx.Request.ReadFormAsync();
+                var capturedData = form.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.ToString());
+                CapturedParRequests.Add(capturedData);
             }
 
             await next();

--- a/access-token-management/test/AccessTokenManagement.Tests/Framework/IntegrationTestBase.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Framework/IntegrationTestBase.cs
@@ -97,6 +97,49 @@ public abstract class IntegrationTestBase : IAsyncDisposable
             AccessTokenLifetime = 10
         });
 
+        IdentityServerHost.Clients.Add(new Client
+        {
+            ClientId = "par-assertion",
+            ClientSecrets =
+            {
+                new Secret
+                {
+                    Type = IdentityServerConstants.SecretTypes.JsonWebKey,
+                    Value = BuildPublicJwk(ClientAssertionPrivateJwk)
+                }
+            },
+            AllowedGrantTypes = GrantTypes.CodeAndClientCredentials,
+            RedirectUris = { "https://app/signin-oidc" },
+            PostLogoutRedirectUris = { "https://app/signout-callback-oidc" },
+            AllowOfflineAccess = true,
+            AllowedScopes = { "openid", "profile", "scope1", "scope2" },
+            RequirePushedAuthorization = true,
+            AccessTokenLifetime = 10
+        });
+
+        IdentityServerHost.Clients.Add(new Client
+        {
+            ClientId = "par-dpop-assertion",
+            ClientSecrets =
+            {
+                new Secret
+                {
+                    Type = IdentityServerConstants.SecretTypes.JsonWebKey,
+                    Value = BuildPublicJwk(ClientAssertionPrivateJwk)
+                }
+            },
+            AllowedGrantTypes = GrantTypes.CodeAndClientCredentials,
+            RedirectUris = { "https://app/signin-oidc" },
+            PostLogoutRedirectUris = { "https://app/signout-callback-oidc" },
+            AllowOfflineAccess = true,
+            AllowedScopes = { "openid", "profile", "scope1", "scope2" },
+            RequirePushedAuthorization = true,
+            RequireDPoP = true,
+            DPoPValidationMode = DPoPTokenExpirationValidationMode.Nonce,
+            DPoPClockSkew = TimeSpan.FromMilliseconds(10),
+            AccessTokenLifetime = 10
+        });
+
         ApiHost = new ApiHost(output.WriteLine, IdentityServerHost, ["scope1", "scope2"]);
         AppHost = new AppHost(output.WriteLine, IdentityServerHost, ApiHost, clientId, configureUserTokenManagementOptions: configureUserTokenManagementOptions);
     }

--- a/access-token-management/test/AccessTokenManagement.Tests/PARWithClientAssertionsTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/PARWithClientAssertionsTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Net.Http.Json;
+using Duende.AccessTokenManagement.DPoP;
+using Duende.AccessTokenManagement.Framework;
+using Duende.IdentityModel;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using JsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
+
+namespace Duende.AccessTokenManagement;
+
+public sealed class PARWithClientAssertionsTests : IntegrationTestBase
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+
+    public PARWithClientAssertionsTests(ITestOutputHelper output)
+        : base(output, "par-assertion")
+    {
+        IdentityServerHost.EnablePar = true;
+        AppHost.PushedAuthorizationBehavior = PushedAuthorizationBehavior.Require;
+        AppHost.ClientAssertionSigningCredentials =
+            new SigningCredentials(new JsonWebKey(ClientAssertionPrivateJwk), "RS256");
+    }
+
+    [Fact]
+    public async Task LoginWithPARAndClientAssertionsShouldSucceed()
+    {
+        await InitializeAsync();
+        await AppHost.LoginAsync("alice");
+
+        // Verify the PAR request contained client assertion
+        var parRequest = IdentityServerHost.CapturedParRequests.ShouldHaveSingleItem();
+        parRequest.ShouldContainKeyAndValue(OidcConstants.TokenRequest.ClientAssertionType,
+            OidcConstants.ClientAssertionTypes.JwtBearer);
+        parRequest.ShouldContainKey(OidcConstants.TokenRequest.ClientAssertion);
+
+        // Verify code exchange also used client assertion
+        var codeExchangeRequest = IdentityServerHost.CapturedTokenRequests
+            .FirstOrDefault(r => r.TryGetValue("grant_type", out var gt) && gt == "authorization_code");
+        codeExchangeRequest.ShouldNotBeNull();
+        codeExchangeRequest.ShouldContainKeyAndValue(OidcConstants.TokenRequest.ClientAssertionType,
+            OidcConstants.ClientAssertionTypes.JwtBearer);
+        codeExchangeRequest.ShouldContainKey(OidcConstants.TokenRequest.ClientAssertion);
+    }
+
+    [Fact]
+    public async Task PARRequestShouldNotContainDPoPJktWhenDPoPNotConfigured()
+    {
+        await InitializeAsync();
+        await AppHost.LoginAsync("alice");
+
+        var parRequest = IdentityServerHost.CapturedParRequests.ShouldHaveSingleItem();
+        parRequest.ShouldNotContainKey(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
+    }
+}
+
+public sealed class PARWithDPoPAndClientAssertionsTests : IntegrationTestBase
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+
+    public PARWithDPoPAndClientAssertionsTests(ITestOutputHelper output)
+        : base(output, "par-dpop-assertion",
+            configureUserTokenManagementOptions: opt => { opt.DPoPJsonWebKey = DPoPProofKey.Parse(DPoPPrivateJwk); })
+    {
+        IdentityServerHost.EnablePar = true;
+        AppHost.PushedAuthorizationBehavior = PushedAuthorizationBehavior.Require;
+        AppHost.ClientAssertionSigningCredentials =
+            new SigningCredentials(new JsonWebKey(ClientAssertionPrivateJwk), "RS256");
+    }
+
+    [Fact]
+    public async Task LoginWithPARAndDPoPAndClientAssertionsShouldSucceed()
+    {
+        await InitializeAsync();
+        await AppHost.LoginAsync("alice");
+
+        // Verify PAR request has client assertion AND dpop_jkt
+        var parRequest = IdentityServerHost.CapturedParRequests.ShouldHaveSingleItem();
+        parRequest.ShouldContainKeyAndValue(OidcConstants.TokenRequest.ClientAssertionType,
+            OidcConstants.ClientAssertionTypes.JwtBearer);
+        parRequest.ShouldContainKey(OidcConstants.TokenRequest.ClientAssertion);
+        parRequest.ShouldContainKey(OidcConstants.AuthorizeRequest.DPoPKeyThumbprint);
+        parRequest[OidcConstants.AuthorizeRequest.DPoPKeyThumbprint].ShouldNotBeNullOrEmpty();
+
+        // Verify we got a DPoP token back
+        var response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"), _ct);
+        var token = await response.Content.ReadFromJsonAsync<UserTokenModel>(_ct);
+        token.ShouldNotBeNull();
+        token.AccessTokenType.ShouldBe("DPoP");
+    }
+
+    [Fact]
+    public async Task RefreshWithPARAndDPoPAndClientAssertionsShouldSucceed()
+    {
+        // Use always-null nonce store so the server always issues a nonce challenge,
+        // guaranteeing the DPoP nonce retry deterministically (no wall-clock dependency).
+        AppHost.OnConfigureServices += services =>
+            services.AddSingleton<IDPoPNonceStore>(new TestDPoPNonceStore());
+
+        await InitializeAsync();
+        await AppHost.LoginAsync("alice");
+
+        // This forces a refresh (token lifetime is 10s, within RefreshBeforeExpiration window)
+        var response = await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"), _ct);
+        var token = await response.Content.ReadFromJsonAsync<UserTokenModel>(_ct);
+        token.ShouldNotBeNull();
+        token.AccessTokenType.ShouldBe("DPoP");
+
+        // Verify refresh token requests used client assertions
+        var refreshRequests = IdentityServerHost.CapturedTokenRequests
+            .Where(r => r.TryGetValue("grant_type", out var gt) && gt == "refresh_token")
+            .ToList();
+        refreshRequests.ShouldNotBeEmpty();
+        foreach (var req in refreshRequests)
+        {
+            req.ShouldContainKeyAndValue(OidcConstants.TokenRequest.ClientAssertionType,
+                OidcConstants.ClientAssertionTypes.JwtBearer);
+            req.ShouldContainKey(OidcConstants.TokenRequest.ClientAssertion);
+        }
+    }
+
+    private const string DPoPPrivateJwk =
+        """
+        {
+            "kty":"RSA",
+            "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+            "e":"AQAB",
+            "d":"X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q",
+            "p":"83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs",
+            "q":"3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk",
+            "dp":"G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0",
+            "dq":"s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk",
+            "qi":"GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU",
+            "alg":"RS256",
+            "kid":"2011-04-29"
+        }
+        """;
+}


### PR DESCRIPTION

## Problem statement
When the authorization server supports Pushed Authorization Requests (PAR), the ASP.NET Core OIDC handler makes a backchannel POST to the PAR endpoint before redirecting the user. `ConfigureOpenIdConnectOptions` does not wrap the `OnPushAuthorization` event, so:

1. **The JWT client assertion is not included** in the PAR request body. The `IClientAssertionService` is never called for PAR requests — only for code exchange (`OnAuthorizationCodeReceived`).
2. **The `dpop_jkt` parameter is not included** in the PAR request. It's currently only added during `OnRedirectToIdentityProvider`, but when PAR is active the authorize parameters are sent in the backchannel PAR request, not the front-channel redirect.

This means clients using `private_key_jwt` authentication cannot use PAR — the authorization server rejects the unauthenticated PAR request.

Per [RFC 9126 §2](https://www.rfc-editor.org/rfc/rfc9126#section-2), the PAR endpoint requires client authentication using the same method as the token endpoint:

> The client is authenticated in the same way as at the token endpoint.

The `WebJarJwt` sample works around this with an explicit opt-out:
```csharp
// Disable PAR because it is incompatible with currently wired up OidcEvents
options.PushedAuthorizationBehavior = PushedAuthorizationBehavior.Disable;
```

## Solution

Add a handler for `options.Events.OnPushAuthorization` and calculate both a dpop proof and add the jwt. 