### PR TITLE
prevent nre in non httpcontext scenario

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/BlazorServerUserAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/BlazorServerUserAccessor.cs
@@ -43,7 +43,7 @@ internal class BlazorServerUserAccessor(
 
         // If we are in neither blazor server or SSR, something weird is going on.
         logger.LogWarning("Neither an authentication state provider or http context are available to obtain the current principal.");
-        return new ClaimsPrincipal();
+        return new ClaimsPrincipal(new ClaimsIdentity());
     }
 
 }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/HttpContextUserAccessor.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/HttpContextUserAccessor.cs
@@ -19,5 +19,5 @@ internal class HttpContextUserAccessor : IUserAccessor
     public HttpContextUserAccessor(IHttpContextAccessor httpContextAccessor) => _httpContextAccessor = httpContextAccessor;
 
     /// <inheritdoc/>
-    public Task<ClaimsPrincipal> GetCurrentUserAsync(CT ct = default) => Task.FromResult(_httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal());
+    public Task<ClaimsPrincipal> GetCurrentUserAsync(CT ct = default) => Task.FromResult(_httpContextAccessor.HttpContext?.User ?? new ClaimsPrincipal(new ClaimsIdentity()));
 }

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/UserAccessTokenManagementService.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/UserAccessTokenManagementService.cs
@@ -34,7 +34,7 @@ internal class UserAccessAccessTokenManager(
 
         parameters ??= new UserTokenRequestParameters();
 
-        if (!user.Identity!.IsAuthenticated)
+        if (user.Identity is not { IsAuthenticated: true })
         {
             logger.CannotRetrieveAccessTokenDueToNoActiveUser(LogLevel.Information);
             return TokenResult.Failure("No active user");

--- a/access-token-management/test/AccessTokenManagement.Tests/UserAccessAccessTokenManagerTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/UserAccessAccessTokenManagerTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Security.Claims;
+using Duende.AccessTokenManagement.OTel;
+using Duende.AccessTokenManagement.OpenIdConnect;
+using Duende.AccessTokenManagement.OpenIdConnect.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Duende.AccessTokenManagement;
+
+public class UserAccessAccessTokenManagerTests
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task GetAccessTokenAsync_with_null_identity_should_return_failure()
+    {
+        // A ClaimsPrincipal created with no arguments has Identity == null.
+        // This happens when HttpContextUserAccessor falls back because
+        // there is no HttpContext (e.g., background service).
+        var user = new ClaimsPrincipal();
+
+        var sut = CreateSut();
+
+        var result = await sut.GetAccessTokenAsync(user, ct: _ct);
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailedResult.ShouldNotBeNull();
+        result.FailedResult.Error.ShouldBe("No active user");
+    }
+
+    [Fact]
+    public async Task GetAccessTokenAsync_with_unauthenticated_identity_should_return_failure()
+    {
+        // A ClaimsPrincipal with an empty ClaimsIdentity is unauthenticated.
+        var user = new ClaimsPrincipal(new ClaimsIdentity());
+
+        var sut = CreateSut();
+
+        var result = await sut.GetAccessTokenAsync(user, ct: _ct);
+
+        result.Succeeded.ShouldBeFalse();
+        result.FailedResult.ShouldNotBeNull();
+        result.FailedResult.Error.ShouldBe("No active user");
+    }
+
+    private static UserAccessAccessTokenManager CreateSut()
+    {
+        var metrics = new AccessTokenManagementMetrics(new TestMeterFactory());
+        var sync = new StubUserTokenRequestConcurrencyControl();
+        var store = new StubUserTokenStore();
+        var clock = TimeProvider.System;
+        var options = Options.Create(new UserTokenManagementOptions());
+        var tokenClient = new StubOpenIdConnectUserTokenEndpoint();
+        var logger = new NullLogger<UserAccessAccessTokenManager>();
+
+        return new UserAccessAccessTokenManager(
+            metrics,
+            sync,
+            store,
+            clock,
+            options,
+            tokenClient,
+            logger);
+    }
+
+    private class TestMeterFactory : System.Diagnostics.Metrics.IMeterFactory
+    {
+        public System.Diagnostics.Metrics.Meter Create(System.Diagnostics.Metrics.MeterOptions options) =>
+            new(options);
+
+        public void Dispose() { }
+    }
+
+    private class StubUserTokenRequestConcurrencyControl : IUserTokenRequestConcurrencyControl
+    {
+        public Task<TokenResult<UserToken>> ExecuteWithConcurrencyControlAsync(
+            UserRefreshToken key,
+            Func<Task<TokenResult<UserToken>>> tokenRetriever,
+            CancellationToken ct = default) =>
+            tokenRetriever();
+    }
+
+    private class StubUserTokenStore : IUserTokenStore
+    {
+        public Task<TokenResult<TokenForParameters>> GetTokenAsync(
+            ClaimsPrincipal user,
+            UserTokenRequestParameters? parameters = null,
+            CancellationToken ct = default) =>
+            throw new NotImplementedException("Should not be reached when user has no identity");
+
+        public Task StoreTokenAsync(
+            ClaimsPrincipal user,
+            UserToken token,
+            UserTokenRequestParameters? parameters = null,
+            CancellationToken ct = default) =>
+            throw new NotImplementedException("Should not be reached when user has no identity");
+
+        public Task ClearTokenAsync(
+            ClaimsPrincipal user,
+            UserTokenRequestParameters? parameters = null,
+            CancellationToken ct = default) =>
+            throw new NotImplementedException("Should not be reached when user has no identity");
+    }
+
+    private class StubOpenIdConnectUserTokenEndpoint : IOpenIdConnectUserTokenEndpoint
+    {
+        public Task<TokenResult<UserToken>> RefreshAccessTokenAsync(
+            UserRefreshToken userToken,
+            UserTokenRequestParameters parameters,
+            CancellationToken ct = default) =>
+            throw new NotImplementedException("Should not be reached when user has no identity");
+
+        public Task RevokeRefreshTokenAsync(
+            UserRefreshToken userToken,
+            UserTokenRequestParameters parameters,
+            CancellationToken ct = default) =>
+            throw new NotImplementedException("Should not be reached when user has no identity");
+    }
+}

--- a/access-token-management/test/AccessTokenManagement.Tests/UserAccessAccessTokenManagerTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/UserAccessAccessTokenManagerTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Security.Claims;
-using Duende.AccessTokenManagement.OTel;
 using Duende.AccessTokenManagement.OpenIdConnect;
 using Duende.AccessTokenManagement.OpenIdConnect.Internal;
+using Duende.AccessTokenManagement.OTel;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -18,8 +18,7 @@ public class UserAccessAccessTokenManagerTests
     public async Task GetAccessTokenAsync_with_null_identity_should_return_failure()
     {
         // A ClaimsPrincipal created with no arguments has Identity == null.
-        // This happens when HttpContextUserAccessor falls back because
-        // there is no HttpContext (e.g., background service).
+        // This can happen if a custom IUserAccessor returns a default principal.
         var user = new ClaimsPrincipal();
 
         var sut = CreateSut();
@@ -28,7 +27,7 @@ public class UserAccessAccessTokenManagerTests
 
         result.Succeeded.ShouldBeFalse();
         result.FailedResult.ShouldNotBeNull();
-        result.FailedResult.Error.ShouldBe("No active user");
+        result.FailedResult!.Error.ShouldBe("No active user");
     }
 
     [Fact]
@@ -43,7 +42,7 @@ public class UserAccessAccessTokenManagerTests
 
         result.Succeeded.ShouldBeFalse();
         result.FailedResult.ShouldNotBeNull();
-        result.FailedResult.Error.ShouldBe("No active user");
+        result.FailedResult!.Error.ShouldBe("No active user");
     }
 
     private static UserAccessAccessTokenManager CreateSut()


### PR DESCRIPTION
Fixes DuendeSoftware/foss#324

OpenIdConnectUserAccessTokenHandler throws a NullReferenceException when used outside an HTTP request context (e.g., in a background service). When HttpContext is null, HttpContextUserAccessor falls back to new ClaimsPrincipal(), which has a null Identity. The null-forgiving operator in UserAccessAccessTokenManager.GetAccessTokenAsync (user.Identity!.IsAuthenticated) then causes the NRE, preventing the intended "No active user" failure result from being returned.