### PR TITLE
Introduce the capability to refresh the dpop proof on a retry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Duende.IdentityModel" Version="8.0.1" />
+    <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
     <PackageVersion Include="Duende.IdentityServer" Version="7.4.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/ClientAssertionService.cs
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/ClientAssertionService.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Security.Cryptography;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace ConsoleClientWithBrowser;
+
+/// <summary>
+/// Creates signed client assertion JWTs (RFC 7523 / private_key_jwt).
+/// Each call to <see cref="CreateAssertionAsync"/> produces a JWT with a fresh
+/// <c>jti</c> and <c>iat</c>, which is critical when retries (e.g. DPoP nonce
+/// challenges) require a new assertion to avoid replay rejection.
+/// </summary>
+public class ClientAssertionService
+{
+    private readonly string _clientId;
+    private readonly string _audience;
+    private readonly SigningCredentials _signingCredentials;
+
+    public ClientAssertionService(string clientId, string audience, SigningCredentials signingCredentials)
+    {
+        _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+        _audience = audience ?? throw new ArgumentNullException(nameof(audience));
+        _signingCredentials = signingCredentials ?? throw new ArgumentNullException(nameof(signingCredentials));
+    }
+
+    /// <summary>
+    /// Creates a fresh <see cref="ClientAssertion"/> with a unique <c>jti</c>.
+    /// </summary>
+    public Task<ClientAssertion> CreateAssertionAsync()
+    {
+        var now = DateTime.UtcNow;
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _clientId,
+            Audience = _audience,
+            IssuedAt = now,
+            NotBefore = now,
+            Expires = now.AddMinutes(1),
+            SigningCredentials = _signingCredentials,
+            AdditionalHeaderClaims = new Dictionary<string, object>
+            {
+                { "typ", "client-authentication+jwt" }
+            },
+            Claims = new Dictionary<string, object>
+            {
+                { JwtClaimTypes.JwtId, Guid.NewGuid().ToString() },
+                { JwtClaimTypes.Subject, _clientId },
+            }
+        };
+
+        var handler = new JsonWebTokenHandler();
+        var jwt = handler.CreateToken(descriptor);
+
+        return Task.FromResult(new ClientAssertion
+        {
+            Type = OidcConstants.ClientAssertionTypes.JwtBearer,
+            Value = jwt
+        });
+    }
+
+    /// <summary>
+    /// Creates a new RSA signing credential suitable for client assertion signing.
+    /// </summary>
+    public static SigningCredentials CreateSigningCredentials()
+    {
+        var rsa = RSA.Create(2048);
+        var key = new RsaSecurityKey(rsa);
+        return new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
+    }
+}

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/NetCoreConsoleClient.csproj
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/NetCoreConsoleClient.csproj
@@ -4,14 +4,16 @@
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>NetCoreConsoleClient</AssemblyName>
     <OutputType>Exe</OutputType>
+    <ImplicitUsings>true</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
 	  <FrameworkReference Include="Microsoft.AspNetCore.App"></FrameworkReference>
-	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.0" />
+    <ProjectReference Include="../../../../src/IdentityModel.OidcClient.Extensions/IdentityModel.OidcClient.Extensions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/Program.cs
+++ b/identity-model-oidc-client/samples/NetCoreConsoleClient/src/NetCoreConsoleClient/Program.cs
@@ -1,134 +1,174 @@
-﻿using Duende.IdentityModel.Client;
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+//
+// This sample demonstrates using OidcClient with DPoP and a ClientAssertionFactory
+// so that DPoP nonce retries automatically regenerate the client_assertion JWT.
+//
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient;
-using Newtonsoft.Json.Linq;
+using Duende.IdentityModel.OidcClient.DPoP;
+using Microsoft.IdentityModel.Tokens;
 using Serilog;
 
-namespace ConsoleClientWithBrowser
+namespace ConsoleClientWithBrowser;
+
+public class Program
 {
-    public class Program
+    static string _authority = "https://demo.duendesoftware.com";
+    static string _api = "https://demo.duendesoftware.com/api/test";
+
+    static HttpClient _apiClient = new HttpClient { BaseAddress = new Uri(_api) };
+
+    public static void Main(string[] args) => MainAsync().GetAwaiter().GetResult();
+
+    public static async Task MainAsync()
     {
-        static string _authority = "https://demo.duendesoftware.com";
-        static string _api = "https://demo.duendesoftware.com/api/test";
+        Console.WriteLine("+-----------------------------------------+");
+        Console.WriteLine("|  Sign in with OIDC + DPoP + Assertion   |");
+        Console.WriteLine("+-----------------------------------------+");
+        Console.WriteLine("");
+        Console.WriteLine("Press any key to sign in...");
+        Console.ReadKey();
 
-        static HttpClient _apiClient = new HttpClient { BaseAddress = new Uri(_api) };
+        await Login();
+    }
 
-        public static void Main(string[] args) => MainAsync().GetAwaiter().GetResult();
+    private static async Task Login()
+    {
+        // create a redirect URI using an available port on the loopback address.
+        var browser = new SystemBrowser();
+        string redirectUri = string.Format($"http://127.0.0.1:{browser.Port}");
 
-        public static async Task MainAsync()
+        // Create a DPoP proof key
+        var dpopKey = CreateDPoPProofKey();
+
+        // Create a client assertion signing key and service
+        var signingCredentials = ClientAssertionService.CreateSigningCredentials();
+
+        var options = new OidcClientOptions
         {
-            Console.WriteLine("+-----------------------+");
-            Console.WriteLine("|  Sign in with OIDC    |");
-            Console.WriteLine("+-----------------------+");
-            Console.WriteLine("");
-            Console.WriteLine("Press any key to sign in...");
-            Console.ReadKey();
+            Authority = _authority,
+            ClientId = "interactive.public",
+            RedirectUri = redirectUri,
+            Scope = "openid profile api",
+            FilterClaims = false,
+            Browser = browser,
+        };
 
-            await Login();
+        // Wire up DPoP
+        options.ConfigureDPoP(dpopKey);
+
+        // Wire up the client assertion factory.
+        // The factory produces a fresh JWT (with unique jti) on each invocation,
+        // which ensures DPoP nonce retries don't replay a stale assertion.
+        var assertionService = new ClientAssertionService(
+            clientId: options.ClientId,
+            audience: _authority,
+            signingCredentials: signingCredentials);
+        options.GetClientAssertionAsync = assertionService.CreateAssertionAsync;
+
+        var serilog = new LoggerConfiguration()
+            .MinimumLevel.Error()
+            .Enrich.FromLogContext()
+            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message}{NewLine}{Exception}{NewLine}")
+            .CreateLogger();
+
+        options.LoggerFactory.AddSerilog(serilog);
+
+        var oidcClient = new OidcClient(options);
+        var result = await oidcClient.LoginAsync(new LoginRequest());
+
+        ShowResult(result);
+        await NextSteps(result, oidcClient);
+    }
+
+    /// <summary>
+    /// Creates a DPoP proof key (RSA, serialized as JWK JSON).
+    /// In production, persist this key so the same key is used across restarts.
+    /// </summary>
+    private static string CreateDPoPProofKey()
+    {
+        using var rsa = RSA.Create(2048);
+        var key = new RsaSecurityKey(rsa);
+        var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(key);
+        jwk.Alg = SecurityAlgorithms.RsaSha256;
+        return JsonSerializer.Serialize(jwk);
+    }
+
+    private static void ShowResult(LoginResult result)
+    {
+        if (result.IsError)
+        {
+            Console.WriteLine("\n\nError:\n{0}", result.Error);
+            return;
         }
 
-        private static async Task Login()
+        Console.WriteLine("\n\nClaims:");
+        foreach (var claim in result.User.Claims)
         {
-            // create a redirect URI using an available port on the loopback address.
-            // requires the OP to allow random ports on 127.0.0.1 - otherwise set a static port
-            var browser = new SystemBrowser();
-            string redirectUri = string.Format($"http://127.0.0.1:{browser.Port}");
-
-            var options = new OidcClientOptions
-            {
-                Authority = _authority,
-                ClientId = "interactive.public",
-                RedirectUri = redirectUri,
-                Scope = "openid profile api",
-                FilterClaims = false,
-                Browser = browser,
-            };
-
-            var serilog = new LoggerConfiguration()
-                .MinimumLevel.Error()
-                .Enrich.FromLogContext()
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message}{NewLine}{Exception}{NewLine}")
-                .CreateLogger();
-
-            options.LoggerFactory.AddSerilog(serilog);
-
-            var oidcClient = new OidcClient(options);
-            var result = await oidcClient.LoginAsync(new LoginRequest());
-
-            ShowResult(result);
-            await NextSteps(result, oidcClient);
+            Console.WriteLine("{0}: {1}", claim.Type, claim.Value);
         }
 
-        private static void ShowResult(LoginResult result)
+        Console.WriteLine($"\nidentity token: {result.IdentityToken}");
+        Console.WriteLine($"access token:   {result.AccessToken}");
+        Console.WriteLine($"refresh token:  {result?.RefreshToken ?? "none"}");
+    }
+
+    private static async Task NextSteps(LoginResult result, OidcClient oidcClient)
+    {
+        var currentAccessToken = result.AccessToken;
+        var currentRefreshToken = result.RefreshToken;
+
+        var menu = "  x...exit  c...call api   ";
+        if (currentRefreshToken != null) menu += "r...refresh token   ";
+
+        while (true)
         {
-            if (result.IsError)
+            Console.WriteLine("\n\n");
+
+            Console.Write(menu);
+            var key = Console.ReadKey();
+
+            if (key.Key == ConsoleKey.X) return;
+            if (key.Key == ConsoleKey.C) await CallApi(currentAccessToken);
+            if (key.Key == ConsoleKey.R)
             {
-                Console.WriteLine("\n\nError:\n{0}", result.Error);
-                return;
-            }
-
-            Console.WriteLine("\n\nClaims:");
-            foreach (var claim in result.User.Claims)
-            {
-                Console.WriteLine("{0}: {1}", claim.Type, claim.Value);
-            }
-
-            Console.WriteLine($"\nidentity token: {result.IdentityToken}");
-            Console.WriteLine($"access token:   {result.AccessToken}");
-            Console.WriteLine($"refresh token:  {result?.RefreshToken ?? "none"}");
-        }
-
-        private static async Task NextSteps(LoginResult result, OidcClient oidcClient)
-        {
-            var currentAccessToken = result.AccessToken;
-            var currentRefreshToken = result.RefreshToken;
-
-            var menu = "  x...exit  c...call api   ";
-            if (currentRefreshToken != null) menu += "r...refresh token   ";
-
-            while (true)
-            {
-                Console.WriteLine("\n\n");
-
-                Console.Write(menu);
-                var key = Console.ReadKey();
-
-                if (key.Key == ConsoleKey.X) return;
-                if (key.Key == ConsoleKey.C) await CallApi(currentAccessToken);
-                if (key.Key == ConsoleKey.R)
+                var refreshResult = await oidcClient.RefreshTokenAsync(currentRefreshToken);
+                if (refreshResult.IsError)
                 {
-                    var refreshResult = await oidcClient.RefreshTokenAsync(currentRefreshToken);
-                    if (refreshResult.IsError)
-                    {
-                        Console.WriteLine($"Error: {refreshResult.Error}");
-                    }
-                    else
-                    {
-                        currentRefreshToken = refreshResult.RefreshToken;
-                        currentAccessToken = refreshResult.AccessToken;
+                    Console.WriteLine($"Error: {refreshResult.Error}");
+                }
+                else
+                {
+                    currentRefreshToken = refreshResult.RefreshToken;
+                    currentAccessToken = refreshResult.AccessToken;
 
-                        Console.WriteLine("\n\n");
-                        Console.WriteLine($"access token:   {refreshResult.AccessToken}");
-                        Console.WriteLine($"refresh token:  {refreshResult?.RefreshToken ?? "none"}");
-                    }
+                    Console.WriteLine("\n\n");
+                    Console.WriteLine($"access token:   {refreshResult.AccessToken}");
+                    Console.WriteLine($"refresh token:  {refreshResult?.RefreshToken ?? "none"}");
                 }
             }
         }
+    }
 
-        private static async Task CallApi(string currentAccessToken)
+    private static async Task CallApi(string currentAccessToken)
+    {
+        _apiClient.SetBearerToken(currentAccessToken);
+        var response = await _apiClient.GetAsync("");
+
+        if (response.IsSuccessStatusCode)
         {
-            _apiClient.SetBearerToken(currentAccessToken);
-            var response = await _apiClient.GetAsync("");
-
-            if (response.IsSuccessStatusCode)
-            {
-                var json = JArray.Parse(await response.Content.ReadAsStringAsync());
-                Console.WriteLine("\n\n");
-                Console.WriteLine(json);
-            }
-            else
-            {
-                Console.WriteLine($"Error: {response.ReasonPhrase}");
-            }
+            var json = await response.Content.ReadAsStringAsync();
+            Console.WriteLine("\n\n");
+            Console.WriteLine(json);
+        }
+        else
+        {
+            Console.WriteLine($"Error: {response.ReasonPhrase}");
         }
     }
 }

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/ProofTokenMessageHandler.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient.Extensions/DPoP/ProofTokenMessageHandler.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Duende Software. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Web;
+using Duende.IdentityModel.Client;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Duende.IdentityModel.OidcClient.DPoP;
 
 /// <summary>
@@ -9,14 +14,24 @@ namespace Duende.IdentityModel.OidcClient.DPoP;
 public class ProofTokenMessageHandler : DelegatingHandler
 {
     private readonly IDPoPProofTokenFactory _proofTokenFactory;
+    private readonly ILogger _logger;
     private string? _nonce;
 
     /// <summary>
     /// Constructor
     /// </summary>
     public ProofTokenMessageHandler(IDPoPProofTokenFactory dPoPProofTokenFactory, HttpMessageHandler innerHandler)
+        : this(dPoPProofTokenFactory, innerHandler, NullLogger<ProofTokenMessageHandler>.Instance)
+    {
+    }
+
+    /// <summary>
+    /// Constructor with logger support
+    /// </summary>
+    public ProofTokenMessageHandler(IDPoPProofTokenFactory dPoPProofTokenFactory, HttpMessageHandler innerHandler, ILogger<ProofTokenMessageHandler> logger)
     {
         _proofTokenFactory = dPoPProofTokenFactory ?? throw new ArgumentNullException(nameof(dPoPProofTokenFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         InnerHandler = innerHandler ?? throw new ArgumentNullException(nameof(innerHandler));
     }
 
@@ -40,6 +55,9 @@ public class ProofTokenMessageHandler : DelegatingHandler
                 response.Dispose();
 
                 CreateProofToken(request);
+
+                // Regenerate the client assertion to ensure a fresh jti on retry.
+                await RefreshClientAssertionAsync(request).ConfigureAwait(false);
 
                 response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
@@ -66,5 +84,67 @@ public class ProofTokenMessageHandler : DelegatingHandler
         var proof = _proofTokenFactory.CreateProofToken(proofRequest);
 
         request.SetDPoPProofToken(proof.ProofToken);
+    }
+
+    /// <summary>
+    /// Reads the <see cref="ProtocolRequestOptions.ClientAssertionFactory"/> from
+    /// <see cref="HttpRequestMessage.Options"/> and, if present, invokes it to obtain a
+    /// fresh <see cref="ClientAssertion"/>. The assertion replaces the
+    /// <c>client_assertion</c> and <c>client_assertion_type</c> form fields in the
+    /// request body while preserving all other parameters.
+    /// </summary>
+    private async Task RefreshClientAssertionAsync(HttpRequestMessage request)
+    {
+        if (request.Content == null)
+        {
+            return;
+        }
+
+        if (!request.Options.TryGetValue(ProtocolRequestOptions.ClientAssertionFactory, out var factory) ||
+            factory == null)
+        {
+            return;
+        }
+
+        ClientAssertion? assertion;
+        try
+        {
+            assertion = await factory().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // If the factory throws, leave the body unchanged and let the retry proceed.
+            _logger.LogWarning(ex, "Client assertion factory threw an exception during DPoP nonce retry. " +
+                                   "The retry will proceed with the original assertion.");
+            return;
+        }
+
+        if (assertion == null)
+        {
+            return;
+        }
+
+        string bodyString;
+        try
+        {
+            bodyString = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read request body while refreshing client assertion during DPoP nonce retry. " +
+                                   "The retry will proceed with the original assertion.");
+            return;
+        }
+
+        // Parse the application/x-www-form-urlencoded body.
+        var parsed = HttpUtility.ParseQueryString(bodyString);
+
+        parsed[OidcConstants.TokenRequest.ClientAssertionType] = assertion.Type;
+        parsed[OidcConstants.TokenRequest.ClientAssertion] = assertion.Value;
+
+        request.Content = new StringContent(
+            parsed.ToString()!,
+            System.Text.Encoding.UTF8,
+            "application/x-www-form-urlencoded");
     }
 }

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/AuthorizeClient.cs
@@ -139,6 +139,7 @@ internal class AuthorizeClient
 
             ClientSecret = _options.ClientSecret,
             ClientAssertion = await _options.GetClientAssertionAsync(),
+            ClientAssertionFactory = _options.GetClientAssertionAsync,
             Parameters = CreateAuthorizeParameters(state, codeChallenge, frontChannelParameters),
         };
 

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/OidcClient.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/OidcClient.cs
@@ -205,7 +205,7 @@ public class OidcClient
             return new LoginResult(result.Error, result.ErrorDescription);
         }
 
-        var userInfoClaims = Enumerable.Empty<Claim>();
+        var userInfoClaims = Array.Empty<Claim>();
         if (Options.LoadProfile)
         {
             var userInfoResult = await GetUserInfoAsync(result.TokenResponse.AccessToken, cancellationToken);
@@ -217,7 +217,7 @@ public class OidcClient
                 return new LoginResult(error);
             }
 
-            userInfoClaims = userInfoResult.Claims;
+            userInfoClaims = userInfoResult.Claims.ToArray();
 
             var userInfoSub = userInfoClaims.FirstOrDefault(c => c.Type == JwtClaimTypes.Subject);
             if (userInfoSub == null)
@@ -230,7 +230,7 @@ public class OidcClient
 
             if (result.TokenResponse.IdentityToken != null)
             {
-                if (!string.Equals(userInfoSub.Value, result.User.FindFirst(JwtClaimTypes.Subject).Value))
+                if (!string.Equals(userInfoSub.Value, result.User.FindFirst(JwtClaimTypes.Subject)?.Value))
                 {
                     var error = "sub claim from userinfo endpoint is different than sub claim from identity token.";
                     _logger.LogError(error);
@@ -350,6 +350,7 @@ public class OidcClient
             ClientId = Options.ClientId,
             ClientSecret = Options.ClientSecret,
             ClientAssertion = await Options.GetClientAssertionAsync(),
+            ClientAssertionFactory = Options.GetClientAssertionAsync,
             ClientCredentialStyle = Options.TokenClientCredentialStyle,
             RefreshToken = refreshToken,
             Parameters = backChannelParameters,
@@ -504,6 +505,6 @@ public class OidcClient
             userClaims = combinedClaims.ToList();
         }
 
-        return new ClaimsPrincipal(new ClaimsIdentity(userClaims, user.Identity.AuthenticationType, user.Identities.First().NameClaimType, user.Identities.First().RoleClaimType));
+        return new ClaimsPrincipal(new ClaimsIdentity(userClaims, user.Identity?.AuthenticationType, user.Identities.First().NameClaimType, user.Identities.First().RoleClaimType));
     }
 }

--- a/identity-model-oidc-client/src/IdentityModel.OidcClient/ResponseProcessor.cs
+++ b/identity-model-oidc-client/src/IdentityModel.OidcClient/ResponseProcessor.cs
@@ -182,6 +182,7 @@ internal class ResponseProcessor
             ClientId = _options.ClientId,
             ClientSecret = _options.ClientSecret,
             ClientAssertion = await _options.GetClientAssertionAsync(),
+            ClientAssertionFactory = _options.GetClientAssertionAsync,
             ClientCredentialStyle = _options.TokenClientCredentialStyle,
 
             Code = code,

--- a/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/DPoPTests.cs
+++ b/identity-model-oidc-client/test/IdentityModel.OidcClient.Tests/DPoP/DPoPTests.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Web;
 using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient.DPoP.Framework;
 using Duende.IdentityServer.Models;
@@ -98,7 +99,7 @@ public class DPoPTest : IntegrationTestBase
 
         ApiHost.ApiInvoked += ctx =>
         {
-            ctx.User.Identity.IsAuthenticated.ShouldBeTrue();
+            ctx.User.Identity?.IsAuthenticated.ShouldBeTrue();
         };
 
         var apiResponse = await apiClient.GetAsync(ApiHost.Url("/api"), _ct);
@@ -128,10 +129,157 @@ public class DPoPTest : IntegrationTestBase
 
         ApiHost.ApiInvoked += ctx =>
         {
-            ctx.User.Identity.IsAuthenticated.ShouldBeTrue();
+            ctx.User.Identity?.IsAuthenticated.ShouldBeTrue();
         };
 
         var apiResponse = await apiClient.GetAsync(ApiHost.Url("/api"), _ct);
         apiResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task when_nonce_required_client_assertion_factory_should_be_called_on_retry()
+    {
+        var capturedAssertions = new List<string>();
+        var callCount = 0;
+        var nonce = "test-nonce-value";
+
+        var mockInner = new CallbackHttpMessageHandler(async (request, ct) =>
+        {
+            var body = request.Content != null
+                ? await request.Content.ReadAsStringAsync(ct)
+                : string.Empty;
+            var pairs = HttpUtility.ParseQueryString(body);
+            var assertion = pairs["client_assertion"];
+            if (assertion != null)
+            {
+                capturedAssertions.Add(assertion);
+            }
+
+            callCount++;
+            if (callCount == 1)
+            {
+                var resp = new HttpResponseMessage(HttpStatusCode.BadRequest);
+                resp.Headers.Add("DPoP-Nonce", nonce);
+                resp.Content = new StringContent(
+                    """{"error":"use_dpop_nonce"}""",
+                    System.Text.Encoding.UTF8, "application/json");
+                return resp;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"access_token":"tok","token_type":"DPoP","expires_in":3600}""",
+                    System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        var assertionCallCount = 0;
+        var factory = () =>
+        {
+            assertionCallCount++;
+            return Task.FromResult(new ClientAssertion
+            {
+                Type = OidcConstants.ClientAssertionTypes.JwtBearer,
+                Value = $"assertion_{assertionCallCount}"
+            });
+        };
+
+        var handler = new ProofTokenMessageHandler(_proofTokenFactory, mockInner);
+        var client = new HttpClient(handler);
+
+        var initialContent = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "client_credentials"),
+            new KeyValuePair<string, string>("client_assertion_type", OidcConstants.ClientAssertionTypes.JwtBearer),
+            new KeyValuePair<string, string>("client_assertion", "original_assertion"),
+            new KeyValuePair<string, string>("scope", "scope1"),
+        });
+        var requestMessage = new HttpRequestMessage(HttpMethod.Post, "https://server/connect/token")
+        {
+            Content = initialContent
+        };
+        requestMessage.Options.Set(ProtocolRequestOptions.ClientAssertionFactory, factory);
+
+        await client.SendAsync(requestMessage, _ct);
+
+        callCount.ShouldBe(2, "Expected initial request + nonce retry");
+        capturedAssertions.Count.ShouldBe(2);
+        capturedAssertions[0].ShouldBe("original_assertion",
+            "First request should use the original body's assertion");
+        capturedAssertions[1].ShouldBe("assertion_1",
+            "Retry request should use the fresh assertion from ClientAssertionFactory");
+        assertionCallCount.ShouldBe(1, "ClientAssertionFactory should be called exactly once (on retry)");
+    }
+
+    [Fact]
+    public async Task when_no_client_assertion_factory_nonce_retry_does_not_modify_body()
+    {
+        var capturedAssertions = new List<string>();
+        var callCount = 0;
+        var nonce = "test-nonce-backward-compat";
+
+        var mockInner = new CallbackHttpMessageHandler(async (request, ct) =>
+        {
+            var body = request.Content != null
+                ? await request.Content.ReadAsStringAsync(ct)
+                : string.Empty;
+            var pairs = HttpUtility.ParseQueryString(body);
+            var assertion = pairs["client_assertion"];
+            if (assertion != null)
+            {
+                capturedAssertions.Add(assertion);
+            }
+
+            callCount++;
+            if (callCount == 1)
+            {
+                var resp = new HttpResponseMessage(HttpStatusCode.BadRequest);
+                resp.Headers.Add("DPoP-Nonce", nonce);
+                resp.Content = new StringContent(
+                    """{"error":"use_dpop_nonce"}""",
+                    System.Text.Encoding.UTF8, "application/json");
+                return resp;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"access_token":"tok","token_type":"DPoP","expires_in":3600}""",
+                    System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        // No ClientAssertionFactory set
+        var handler = new ProofTokenMessageHandler(_proofTokenFactory, mockInner);
+        var client = new HttpClient(handler);
+
+        var requestMessage = new HttpRequestMessage(HttpMethod.Post, "https://server/connect/token")
+        {
+            Content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("grant_type", "client_credentials"),
+                new KeyValuePair<string, string>("client_assertion_type", OidcConstants.ClientAssertionTypes.JwtBearer),
+                new KeyValuePair<string, string>("client_assertion", "static_assertion"),
+            })
+        };
+
+        await client.SendAsync(requestMessage, _ct);
+
+        // Both requests should carry the same (unchanged) assertion — backward compatible
+        callCount.ShouldBe(2, "Expected initial request + nonce retry");
+        capturedAssertions.Count.ShouldBe(2);
+        capturedAssertions[0].ShouldBe("static_assertion");
+        capturedAssertions[1].ShouldBe("static_assertion",
+            "Without ClientAssertionFactory, body must not be modified on retry");
+    }
+
+    private sealed class CallbackHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> callback)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => callback(request, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
Part 2 of 3 — split from #329. Stacked on #343.

- Wire client assertion creator into OIDC code exchange flow in `OidcClient` and `ResponseProcessor`
- Update DPoP `ProofTokenMessageHandler` to regenerate assertions on nonce retry
- Add `ClientAssertionService` to `NetCoreConsoleClient` sample
- Expand DPoP test coverage for client assertion scenarios
