### PR TITLE
fix circular dependency

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/ConfigureOpenIdConnectOptions.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/ConfigureOpenIdConnectOptions.cs
@@ -22,10 +22,11 @@ internal class ConfigureOpenIdConnectOptions(
     IHttpContextAccessor httpContextAccessor,
     IOptions<UserTokenManagementOptions> userAccessTokenManagementOptions,
     IAuthenticationSchemeProvider schemeProvider,
-    IClientAssertionService clientAssertionService,
+    IServiceProvider serviceProvider,
     ILoggerFactory loggerFactory) : IConfigureNamedOptions<OpenIdConnectOptions>
 {
     private readonly Scheme _configScheme = GetConfigScheme(userAccessTokenManagementOptions.Value, schemeProvider);
+    private IClientAssertionService ClientAssertionService => serviceProvider.GetRequiredService<IClientAssertionService>();
 
     private ClientCredentialsClientName ClientName => _configScheme.ToClientName();
 
@@ -119,7 +120,7 @@ internal class ConfigureOpenIdConnectOptions(
             }
 
             // Automatically send client assertion during code exchange if a service is registered
-            var assertion = await clientAssertionService
+            var assertion = await ClientAssertionService
                 .GetClientAssertionAsync(ClientName, ct: context.HttpContext.RequestAborted)
                 .ConfigureAwait(false);
 
@@ -162,7 +163,7 @@ internal class ConfigureOpenIdConnectOptions(
             await inner.Invoke(context);
 
             // --- Client assertion ---
-            var assertion = await clientAssertionService
+            var assertion = await ClientAssertionService
                 .GetClientAssertionAsync(ClientName, ct: context.HttpContext.RequestAborted)
                 .ConfigureAwait(false);
 

--- a/access-token-management/test/AccessTokenManagement.Tests/CircularDependencyTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/CircularDependencyTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Duende.AccessTokenManagement.OpenIdConnect;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Duende.AccessTokenManagement;
+
+/// <summary>
+/// Tests that verify the DI registration does not create circular dependencies.
+/// See https://github.com/DuendeSoftware/foss/pull/347 for context.
+/// </summary>
+public class CircularDependencyTests
+{
+    /// <summary>
+    /// Reproduces the circular dependency described in PR #347:
+    ///
+    /// IClientAssertionService (user impl)
+    ///   → IOpenIdConnectConfigurationService
+    ///     → IOptionsMonitor&lt;OpenIdConnectOptions&gt;
+    ///       → IConfigureOptions&lt;OpenIdConnectOptions&gt; (ConfigureOpenIdConnectOptions)
+    ///         → IClientAssertionService  ← CYCLE
+    ///
+    /// The fix in ConfigureOpenIdConnectOptions resolves IClientAssertionService
+    /// lazily via IServiceProvider instead of constructor injection, breaking the cycle.
+    /// </summary>
+    [Fact]
+    public void IClientAssertionService_depending_on_IOpenIdConnectConfigurationService_should_not_cause_circular_dependency()
+    {
+        var services = new ServiceCollection();
+
+        // Register authentication with an OpenIdConnect scheme (minimal setup).
+        services.AddAuthentication(options =>
+            {
+                options.DefaultChallengeScheme = "oidc";
+                options.DefaultSignInScheme = "cookie";
+            })
+            .AddCookie("cookie")
+            .AddOpenIdConnect("oidc", options =>
+            {
+                options.Authority = "https://demo.duendesoftware.com";
+                options.ClientId = "test-client";
+                options.ClientSecret = "secret";
+            });
+
+        // Register ATM's OpenIdConnect services (includes ConfigureOpenIdConnectOptions).
+        services.AddOpenIdConnectAccessTokenManagement();
+
+        // Register a custom IClientAssertionService that depends on
+        // IOpenIdConnectConfigurationService — the exact pattern from the
+        // WebJarJwt sample that triggered the circular dependency before the fix.
+        services.AddTransient<IClientAssertionService, ClientAssertionServiceWithOidcDependency>();
+
+        // ValidateOnBuild detects circular dependencies at container build time.
+        // Before the fix, this would throw:
+        //   "A circular dependency was detected for the service of type
+        //    'Duende.AccessTokenManagement.IClientAssertionService'."
+        var act = () => services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+
+        act.ShouldNotThrow();
+    }
+
+    /// <summary>
+    /// A test implementation of IClientAssertionService that depends on
+    /// IOpenIdConnectConfigurationService, reproducing the dependency chain
+    /// from the WebJarJwt sample that caused the circular dependency.
+    /// </summary>
+    private sealed class ClientAssertionServiceWithOidcDependency(
+        IOpenIdConnectConfigurationService configurationService) : IClientAssertionService
+    {
+        // Keep a reference to prove DI resolved the dependency successfully.
+        private readonly IOpenIdConnectConfigurationService _configurationService = configurationService;
+
+        public Task<ClientAssertion?> GetClientAssertionAsync(
+            ClientCredentialsClientName? clientName = null,
+            TokenRequestParameters? parameters = null,
+            CancellationToken ct = default) =>
+            Task.FromResult<ClientAssertion?>(null);
+    }
+}

--- a/access-token-management/test/AccessTokenManagement.Tests/CircularDependencyTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/CircularDependencyTests.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using Duende.AccessTokenManagement.OpenIdConnect;
-using Duende.IdentityModel;
 using Duende.IdentityModel.Client;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Duende.AccessTokenManagement;


### PR DESCRIPTION
While running one of the samples, I found that there is a circular dependency. 

This can be resolved in the sample, but I figured it's better to solve it in the library, as other people might not run the sample directly. 

```
 ---> (Inner Exception #10) System.InvalidOperationException: Error while validating the service descriptor 'ServiceType: Duende.AccessTokenManagement.IClientAssertionService Lifetime: Transient ImplementationType: WebJarJwt.ClientAssertionService': A circular dependency was detected for the service of type 'Duende.AccessTokenManagement.IClientAssertionService'.
Duende.AccessTokenManagement.IClientAssertionService(WebJarJwt.ClientAssertionService) -> Duende.AccessTokenManagement.OpenIdConnect.IOpenIdConnectConfigurationService(Duende.AccessTokenManagement.OpenIdConnect.Internal.OpenIdConnectConfigurationService) -> Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions>(Microsoft.Extensions.Options.OptionsMonitor<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions>) -> Microsoft.Extensions.Options.IOptionsFactory<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions>(Microsoft.Extensions.Options.OptionsFactory<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions>) -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.Options.IConfigureOptions<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions>> -> Microsoft.Extensions.Options.IConfigureOptions<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions>(Duende.AccessTokenManagement.OpenIdConnect.Internal.ConfigureOpenIdConnectOptions) -> Duende.AccessTokenManagement.IClientAssertionService
```

