### PR TITLE
Allow overriding the maximum length when parsing refresh tokens

### DIFF
--- a/access-token-management/src/AccessTokenManagement/RefreshToken.cs
+++ b/access-token-management/src/AccessTokenManagement/RefreshToken.cs
@@ -11,7 +11,23 @@ namespace Duende.AccessTokenManagement;
 public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
 {
     public const int MaxLength = 4 * 1024;
+
     public override string ToString() => Value;
+
+    /// <summary>
+    /// Changes the maximum length for refresh tokens.
+    /// </summary>
+    /// <param name="maxLength">The new maximum length. Must be a strictly positive value.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxLength"/> is zero or a negative value.</exception>
+    /// <remarks>
+    /// Note that this change is applied statically and will affect all instances of <see cref="RefreshToken"/> across the entire application.
+    /// </remarks>
+    public static void SetMaxLength(int maxLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLength);
+
+        Validators[0] = ValidationRules.MaxLength(maxLength);
+    }
 
     private static readonly ValidationRule<string>[] Validators = [
         // Officially, there's no max length refresh tokens, but 4k is a good limit

--- a/access-token-management/src/AccessTokenManagement/RefreshToken.cs
+++ b/access-token-management/src/AccessTokenManagement/RefreshToken.cs
@@ -10,7 +10,13 @@ namespace Duende.AccessTokenManagement;
 [JsonConverter(typeof(StringValueJsonConverter<RefreshToken>))]
 public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
 {
+    private static int? _overriddenMaxLength;
+    private static ValidationRule<string>[] _validators = [];
+
+    // Officially, there's no max length refresh tokens, but 4k is a good limit
     public const int MaxLength = 4 * 1024;
+
+    static RefreshToken() => InitializeValidators();
 
     public override string ToString() => Value;
 
@@ -26,13 +32,14 @@ public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLength);
 
-        Validators[0] = ValidationRules.MaxLength(maxLength);
+        _overriddenMaxLength = maxLength;
+        InitializeValidators();
     }
 
-    private static readonly ValidationRule<string>[] Validators = [
-        // Officially, there's no max length refresh tokens, but 4k is a good limit
-        ValidationRules.MaxLength(MaxLength)
-    ];
+    private static void InitializeValidators() =>
+        _validators = [
+            ValidationRules.MaxLength(_overriddenMaxLength ?? MaxLength)
+        ];
 
     /// <summary>
     /// You can't directly create this type.
@@ -54,7 +61,7 @@ public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
     /// and also includes a list of errors. This is useful for validating user input or other scenarios where you want to provide feedback
     /// </summary>
     public static bool TryParse(string value, [NotNullWhen(true)] out RefreshToken? parsed, out string[] errors) =>
-        IStronglyTypedValue<RefreshToken>.TryBuildValidatedObject(value, Validators, out parsed, out errors);
+        IStronglyTypedValue<RefreshToken>.TryBuildValidatedObject(value, _validators, out parsed, out errors);
 
     static RefreshToken IStronglyTypedValue<RefreshToken>.Create(string result) => new(result);
 

--- a/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandler/AccessTokenHandlerTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/AccessTokenHandler/AccessTokenHandlerTests.cs
@@ -11,6 +11,10 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Duende.AccessTokenManagement.AccessTokenHandler;
 
+// This class uses <see cref="RefreshToken"/>, whose max length is static mutable state
+// (via <see cref="RefreshToken.SetMaxLength"/>). Sharing a collection with the other
+// RefreshToken test classes prevents parallel execution that could cause flaky failures.
+[Collection(nameof(Types.RefreshTokenTests))]
 public class AccessTokenHandlerTests(ITestOutputHelper output)
 {
     private readonly CancellationToken _ct = TestContext.Current.CancellationToken;

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -184,6 +184,7 @@
         public RefreshToken() { }
         public override string ToString() { }
         public static Duende.AccessTokenManagement.RefreshToken Parse(string value) { }
+        public static void SetMaxLength(int maxLength) { }
         public static bool TryParse(string value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.AccessTokenManagement.RefreshToken? parsed, out string[] errors) { }
         public static string op_Implicit(Duende.AccessTokenManagement.RefreshToken value) { }
     }

--- a/access-token-management/test/AccessTokenManagement.Tests/StoreTokensInAuthenticationPropertiesTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/StoreTokensInAuthenticationPropertiesTests.cs
@@ -10,6 +10,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Duende.AccessTokenManagement;
 
+// This class uses <see cref="RefreshToken"/>, whose max length is static mutable state
+// (via <see cref="RefreshToken.SetMaxLength"/>). Sharing a collection with the other
+// RefreshToken test classes prevents parallel execution that could cause flaky failures.
+[Collection(nameof(Types.RefreshTokenTests))]
 public class StoreTokensInAuthenticationPropertiesTests
 {
     private readonly CancellationToken _ct = TestContext.Current.CancellationToken;

--- a/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenSetMaxLengthTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenSetMaxLengthTests.cs
@@ -3,11 +3,9 @@
 
 namespace Duende.AccessTokenManagement.Types;
 
-/// <summary>
-/// Tests for <see cref="RefreshToken.SetMaxLength"/>. These are isolated into a separate
-/// non-parallel collection because <see cref="RefreshToken.SetMaxLength"/> mutates static state
-/// that would affect other tests running concurrently.
-/// </summary>
+// All test classes that use <see cref="RefreshToken"/> share this collection because
+// <see cref="RefreshToken.SetMaxLength"/> mutates static state. Serializing them
+// prevents flaky failures from concurrent reads/writes of the max length.
 [Collection(nameof(RefreshTokenTests))]
 public class RefreshTokenSetMaxLengthTests : IDisposable
 {

--- a/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenSetMaxLengthTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenSetMaxLengthTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Duende.AccessTokenManagement.Types;
+
+/// <summary>
+/// Tests for <see cref="RefreshToken.SetMaxLength"/>. These are isolated into a separate
+/// non-parallel collection because <see cref="RefreshToken.SetMaxLength"/> mutates static state
+/// that would affect other tests running concurrently.
+/// </summary>
+[Collection(nameof(RefreshTokenTests))]
+public class RefreshTokenSetMaxLengthTests : IDisposable
+{
+    public void Dispose() =>
+        // Reset to the default max length after each test so static state doesn't leak.
+        RefreshToken.SetMaxLength(RefreshToken.MaxLength);
+
+    [Fact]
+    public void SetMaxLength_AllowsLargerTokens()
+    {
+        // Arrange
+        var largeMaxLength = 16 * 1024; // 16 KB, e.g. for ADFS tokens
+        var largeValue = new string('a', RefreshToken.MaxLength + 1); // Exceeds default, within new limit
+        RefreshToken.SetMaxLength(largeMaxLength);
+
+        // Act
+        var result = RefreshToken.Parse(largeValue);
+
+        // Assert
+        result.ToString().ShouldBe(largeValue);
+    }
+
+    [Fact]
+    public void SetMaxLength_StillRejectsTokensExceedingNewLimit()
+    {
+        // Arrange
+        var newMaxLength = 8 * 1024;
+        RefreshToken.SetMaxLength(newMaxLength);
+        var tooLargeValue = new string('a', newMaxLength + 1);
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => RefreshToken.Parse(tooLargeValue));
+        exception.Message.ShouldContain("exceeds maximum length");
+    }
+
+    [Fact]
+    public void SetMaxLength_TryParse_AllowsLargerTokens()
+    {
+        // Arrange
+        var largeMaxLength = 16 * 1024;
+        var largeValue = new string('a', RefreshToken.MaxLength + 1);
+        RefreshToken.SetMaxLength(largeMaxLength);
+
+        // Act
+        var success = RefreshToken.TryParse(largeValue, out var result, out var errors);
+
+        // Assert
+        success.ShouldBeTrue();
+        result.ShouldNotBeNull();
+        result.ToString().ShouldBe(largeValue);
+        errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SetMaxLength_TryParse_StillRejectsTokensExceedingNewLimit()
+    {
+        // Arrange
+        var newMaxLength = 8 * 1024;
+        RefreshToken.SetMaxLength(newMaxLength);
+        var tooLargeValue = new string('a', newMaxLength + 1);
+
+        // Act
+        var success = RefreshToken.TryParse(tooLargeValue, out var result, out var errors);
+
+        // Assert
+        success.ShouldBeFalse();
+        result.ShouldBeNull();
+        errors.ShouldNotBeEmpty();
+        errors[0].ShouldContain("exceeds maximum length");
+    }
+
+    [Fact]
+    public void SetMaxLength_CanReduceLimit()
+    {
+        // Arrange
+        var smallerMaxLength = 100;
+        RefreshToken.SetMaxLength(smallerMaxLength);
+        var value = new string('a', smallerMaxLength + 1);
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => RefreshToken.Parse(value));
+        exception.Message.ShouldContain("exceeds maximum length");
+    }
+
+    [Fact]
+    public void SetMaxLength_AtExactNewLimit_Succeeds()
+    {
+        // Arrange
+        var newMaxLength = 8 * 1024;
+        RefreshToken.SetMaxLength(newMaxLength);
+        var value = new string('a', newMaxLength);
+
+        // Act
+        var result = RefreshToken.Parse(value);
+
+        // Assert
+        result.ToString().ShouldBe(value);
+    }
+
+    [Fact]
+    public void SetMaxLength_Zero_ThrowsArgumentOutOfRangeException() =>
+        // Act & Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => RefreshToken.SetMaxLength(0));
+
+    [Fact]
+    public void SetMaxLength_Negative_ThrowsArgumentOutOfRangeException() =>
+        // Act & Assert
+        Should.Throw<ArgumentOutOfRangeException>(() => RefreshToken.SetMaxLength(-1));
+}

--- a/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenTests.cs
@@ -3,10 +3,9 @@
 
 namespace Duende.AccessTokenManagement.Types;
 
-/// <summary>
-/// Both the <see cref="RefreshTokenTests"/> and <see cref="RefreshTokenSetMaxLengthTests"/> classes share a collection to prevent parallel execution,
-/// since <see cref="RefreshToken.SetMaxLength"/> mutates static state.
-/// </summary>
+// All test classes that use <see cref="RefreshToken"/> share this collection because
+// <see cref="RefreshToken.SetMaxLength"/> mutates static state. Serializing them
+// prevents flaky failures from concurrent reads/writes of the max length.
 [Collection(nameof(RefreshTokenTests))]
 public class RefreshTokenTests
 {

--- a/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/Types/RefreshTokenTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Duende Software. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Duende.AccessTokenManagement.Types;
+
+/// <summary>
+/// Both the <see cref="RefreshTokenTests"/> and <see cref="RefreshTokenSetMaxLengthTests"/> classes share a collection to prevent parallel execution,
+/// since <see cref="RefreshToken.SetMaxLength"/> mutates static state.
+/// </summary>
+[Collection(nameof(RefreshTokenTests))]
+public class RefreshTokenTests
+{
+    [Fact]
+    public void Parse_ValidValue_ReturnsRefreshToken()
+    {
+        // Arrange
+        var validValue = "valid_refresh_token";
+
+        // Act
+        var result = RefreshToken.Parse(validValue);
+
+        // Assert
+        result.ToString().ShouldBe(validValue);
+    }
+
+    [Fact]
+    public void Parse_InvalidValue_ThrowsException()
+    {
+        // Arrange
+        var invalidValue = new string('a', RefreshToken.MaxLength + 1); // Exceeds max length
+
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => RefreshToken.Parse(invalidValue));
+        exception.Message.ShouldContain("exceeds maximum length");
+    }
+
+    [Fact]
+    public void TryParse_ValidValue_ReturnsTrueAndRefreshToken()
+    {
+        // Arrange
+        var validValue = "valid_refresh_token";
+
+        // Act
+        var success = RefreshToken.TryParse(validValue, out var result, out var errors);
+
+        // Assert
+        success.ShouldBeTrue();
+        result.ShouldNotBeNull();
+        result.ToString().ShouldBe(validValue);
+        errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void TryParse_InvalidValue_ReturnsFalseAndErrors()
+    {
+        // Arrange
+        var invalidValue = new string('a', RefreshToken.MaxLength + 1); // Exceeds max length
+
+        // Act
+        var success = RefreshToken.TryParse(invalidValue, out var result, out var errors);
+
+        // Assert
+        success.ShouldBeFalse();
+        result.ShouldBeNull();
+        errors.ShouldNotBeEmpty();
+        errors[0].ShouldContain("exceeds maximum length");
+    }
+
+    [Fact]
+    public void Parse_AtExactMaxLength_ReturnsRefreshToken()
+    {
+        // Arrange
+        var value = new string('a', RefreshToken.MaxLength);
+
+        // Act
+        var result = RefreshToken.Parse(value);
+
+        // Assert
+        result.ToString().ShouldBe(value);
+    }
+
+    [Fact]
+    public void Parse_NullValue_ThrowsException() =>
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => RefreshToken.Parse(null!));
+
+    [Fact]
+    public void Parse_EmptyValue_ThrowsException() =>
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => RefreshToken.Parse(string.Empty));
+
+    [Fact]
+    public void Parse_WhitespaceValue_ThrowsException() =>
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => RefreshToken.Parse("   "));
+
+    [Fact]
+    public void ParameterlessConstructor_ThrowsException()
+    {
+        // Act & Assert
+        var exception = Should.Throw<InvalidOperationException>(() => new RefreshToken());
+        exception.Message.ShouldContain("Can't create null value");
+    }
+
+    [Fact]
+    public void ImplicitStringConversion_ReturnsValue()
+    {
+        // Arrange
+        var value = "my_refresh_token";
+        var token = RefreshToken.Parse(value);
+
+        // Act
+        string converted = token;
+
+        // Assert
+        converted.ShouldBe(value);
+    }
+}


### PR DESCRIPTION
**What issue does this PR address?**

As reported in https://github.com/orgs/DuendeSoftware/discussions/514, ADFS can issue refresh tokens exceeding the current maximum length of 4K.

Since there is no existing documentation around the maximum length of refresh tokens in ADFS, this PR allows one to set their own new maximum length using `RefreshToken.SetMaxLength(8 * 1024);` for example, rather than arbitrarily selecting a new default which may again be too limiting in the future. 

The existing `public const int MaxLength = 4 * 1024;` was kept, so this PR does not introduce a breaking change.
