### PR TITLE
make max token length configurable

### DIFF
--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserTokenEndpoint.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/OpenIdConnectUserTokenEndpoint.cs
@@ -23,6 +23,8 @@ internal class OpenIdConnectUserTokenEndpoint(
     IDPoPProofService dPoPProofService,
     ILogger<OpenIdConnectUserTokenEndpoint> logger) : IOpenIdConnectUserTokenEndpoint
 {
+    private readonly UserTokenManagementOptions _options = options.Value;
+
     /// <inheritdoc/>
     public async Task<TokenResult<UserToken>> RefreshAccessTokenAsync(
         UserRefreshToken refreshToken,
@@ -47,7 +49,7 @@ internal class OpenIdConnectUserTokenEndpoint(
             Address = tokenEndpoint.ToString(),
             ClientId = oidc.ClientId.ToString(),
             ClientSecret = oidc.ClientSecret.ToString(),
-            ClientCredentialStyle = options.Value.ClientCredentialStyle,
+            ClientCredentialStyle = _options.ClientCredentialStyle,
             RefreshToken = refreshToken.RefreshToken.ToString(),
             Parameters = parameters.Parameters
         };
@@ -156,8 +158,9 @@ internal class OpenIdConnectUserTokenEndpoint(
         var token = new UserToken()
         {
             IdentityToken = IdentityToken.ParseOrDefault(response.IdentityToken),
-            AccessToken = AccessToken.Parse(response.AccessToken ??
-                                                  throw new InvalidOperationException("No access token present")),
+            AccessToken = AccessToken.Parse(
+                response.AccessToken ?? throw new InvalidOperationException("No access token present"),
+                _options.TokenMaxLength),
             AccessTokenType = AccessTokenType.ParseOrDefault(response.TokenType),
             DPoPJsonWebKey = dPoPJsonWebKey,
             Expiration = response.ExpiresIn == 0
@@ -165,7 +168,7 @@ internal class OpenIdConnectUserTokenEndpoint(
                 : DateTimeOffset.UtcNow.AddSeconds(response.ExpiresIn),
             RefreshToken = response.RefreshToken == null
                 ? refreshToken.RefreshToken // use input refresh token if none is returned
-                : RefreshToken.Parse(response.RefreshToken),
+                : RefreshToken.Parse(response.RefreshToken, _options.TokenMaxLength),
             Scope = Scope.ParseOrDefault(response.Scope),
             ClientId = oidc.ClientId
         };
@@ -197,7 +200,7 @@ internal class OpenIdConnectUserTokenEndpoint(
 
             ClientId = oidc.ClientId.ToString(),
             ClientSecret = oidc.ClientSecret.ToString(),
-            ClientCredentialStyle = options.Value.ClientCredentialStyle,
+            ClientCredentialStyle = _options.ClientCredentialStyle,
 
             Token = refreshToken.ToString(),
             TokenTypeHint = OidcConstants.TokenTypes.RefreshToken,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/StoreTokensInAuthenticationProperties.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/Internal/StoreTokensInAuthenticationProperties.cs
@@ -47,6 +47,7 @@ internal class StoreTokensInAuthenticationProperties(
     /// <inheritdoc/>
     public TokenResult<TokenForParameters> GetUserToken(AuthenticationProperties authenticationProperties, UserTokenRequestParameters? parameters = null)
     {
+        var tokenMaxLength = tokenManagementOptionsMonitor.CurrentValue.TokenMaxLength;
         var tokens = authenticationProperties.Items.Where(i => i.Key.StartsWith(TokenPrefix)).ToList();
         if (!tokens.Any())
         {
@@ -81,7 +82,7 @@ internal class StoreTokensInAuthenticationProperties(
         var refreshToken = refreshTokenValue == null
             ? null
             : new UserRefreshToken(
-                RefreshToken.Parse(refreshTokenValue),
+                RefreshToken.Parse(refreshTokenValue, tokenMaxLength),
                 DPoPProofKey.ParseOrDefault(dpopKey));
 
         if (accessTokenValue == null && refreshToken != null)
@@ -91,7 +92,9 @@ internal class StoreTokensInAuthenticationProperties(
 
         var userToken = new UserToken
         {
-            AccessToken = AccessToken.Parse(accessTokenValue ?? throw new NullReferenceException("access_token should not be null here.")),
+            AccessToken = AccessToken.Parse(
+                accessTokenValue ?? throw new NullReferenceException("access_token should not be null here."),
+                tokenMaxLength),
             AccessTokenType = AccessTokenType.ParseOrDefault(accessTokenType),
             DPoPJsonWebKey = DPoPProofKey.ParseOrDefault(dpopKey),
             RefreshToken = refreshToken?.RefreshToken,

--- a/access-token-management/src/AccessTokenManagement.OpenIdConnect/UserTokenManagementOptions.cs
+++ b/access-token-management/src/AccessTokenManagement.OpenIdConnect/UserTokenManagementOptions.cs
@@ -12,6 +12,13 @@ namespace Duende.AccessTokenManagement.OpenIdConnect;
 /// </summary>
 public sealed class UserTokenManagementOptions
 {
+    private const int Kilobyte = 1024;
+
+    /// <summary>
+    /// Maximum allowed token length when reading tokens from token responses or authentication state.
+    /// </summary>
+    public int TokenMaxLength { get; set; } = 4 * Kilobyte;
+
     /// <summary>
     /// Name of the authentication scheme to use for deriving token service configuration
     /// (will fall back to configured default challenge scheme if not set)

--- a/access-token-management/src/AccessTokenManagement/AccessToken.cs
+++ b/access-token-management/src/AccessTokenManagement/AccessToken.cs
@@ -13,14 +13,23 @@ namespace Duende.AccessTokenManagement;
 [JsonConverter(typeof(StringValueJsonConverter<AccessToken>))]
 public readonly record struct AccessToken : IStronglyTypedValue<AccessToken>
 {
+    private const int Kilobyte = 1024;
+
     public override string ToString() => Value;
 
-    // Officially, there's no max length for JWTs, but 32k is a good limit
-    public const int MaxLength = 32 * 1024; // 32k
+    // Officially, there's no max length for JWTs, but keep construction bounded.
+    // Runtime read boundaries apply the configurable limit.
+    public const int MaxLength = 100 * Kilobyte;
 
     private static readonly ValidationRule<string>[] Validators = [
         ValidationRules.MaxLength(MaxLength)
     ];
+
+    private static ValidationRule<string>[] BuildValidators(int maxLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLength);
+        return [ValidationRules.MaxLength(maxLength)];
+    }
 
     /// <summary>
     /// Convenience method for converting a <see cref="AccessToken"/> into a string.
@@ -44,10 +53,30 @@ public readonly record struct AccessToken : IStronglyTypedValue<AccessToken>
     public static bool TryParse(string value, [NotNullWhen(true)] out AccessToken? parsed, out string[] errors) =>
         IStronglyTypedValue<AccessToken>.TryBuildValidatedObject(value, Validators, out parsed, out errors);
 
+    /// <summary>
+    /// Parses a value to a <see cref="AccessToken"/> using the supplied maximum length.
+    /// </summary>
+    public static bool TryParse(string value, int maxLength, [NotNullWhen(true)] out AccessToken? parsed, out string[] errors) =>
+        IStronglyTypedValue<AccessToken>.TryBuildValidatedObject(value, BuildValidators(maxLength), out parsed, out errors);
+
     static AccessToken IStronglyTypedValue<AccessToken>.Create(string result) => new(result);
 
     /// <summary>
     /// Parses a value to a <see cref="AccessToken"/>. This will throw an exception if the string is not valid.
     /// </summary>
     public static AccessToken Parse(string value) => StringParsers<AccessToken>.Parse(value);
+
+    /// <summary>
+    /// Parses a value to a <see cref="AccessToken"/> using the supplied maximum length.
+    /// </summary>
+    public static AccessToken Parse(string value, int maxLength)
+    {
+        if (TryParse(value, maxLength, out var parsed, out var errors))
+        {
+            return parsed.Value;
+        }
+
+        throw new InvalidOperationException(
+            $"Received an invalid {nameof(AccessToken)}. Errors: {string.Join("", errors.Select(x => $"{Environment.NewLine}\t - {x}"))}");
+    }
 }

--- a/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementOptions.cs
+++ b/access-token-management/src/AccessTokenManagement/ClientCredentialsTokenManagementOptions.cs
@@ -8,6 +8,13 @@ namespace Duende.AccessTokenManagement;
 /// </summary>
 public sealed class ClientCredentialsTokenManagementOptions
 {
+    private const int Kilobyte = 1024;
+
+    /// <summary>
+    /// Maximum allowed token length when reading tokens from external systems or caches.
+    /// </summary>
+    public int TokenMaxLength { get; set; } = 32 * Kilobyte;
+
     /// <summary>
     /// Used to prefix the cache key
     /// </summary>

--- a/access-token-management/src/AccessTokenManagement/Internal/ClientCredentialsTokenClient.cs
+++ b/access-token-management/src/AccessTokenManagement/Internal/ClientCredentialsTokenClient.cs
@@ -16,12 +16,15 @@ internal class ClientCredentialsTokenClient(
     AccessTokenManagementMetrics metrics,
     IHttpClientFactory httpClientFactory,
     IOptionsMonitor<ClientCredentialsClient> options,
+    IOptions<ClientCredentialsTokenManagementOptions> tokenManagementOptions,
     IClientAssertionService clientAssertionService,
     TimeProvider time,
     IDPoPKeyStore dPoPKeyMaterialService,
     IDPoPProofService dPoPProofService,
     ILogger<ClientCredentialsTokenClient> logger) : IClientCredentialsTokenEndpoint
 {
+    private readonly ClientCredentialsTokenManagementOptions _tokenManagementOptions = tokenManagementOptions.Value;
+
     /// <inheritdoc/>
     public virtual async Task<TokenResult<ClientCredentialsToken>> RequestAccessTokenAsync(
         ClientCredentialsClientName clientName,
@@ -158,7 +161,9 @@ internal class ClientCredentialsTokenClient(
 
         var token = new ClientCredentialsToken
         {
-            AccessToken = AccessToken.Parse(response.AccessToken ?? throw new InvalidOperationException("Access token should not be null")),
+            AccessToken = AccessToken.Parse(
+                response.AccessToken ?? throw new InvalidOperationException("Access token should not be null"),
+                _tokenManagementOptions.TokenMaxLength),
             AccessTokenType = AccessTokenType.ParseOrDefault(response.TokenType),
             DPoPJsonWebKey = dpopJsonWebKey,
             Expiration = response.ExpiresIn == 0

--- a/access-token-management/src/AccessTokenManagement/RefreshToken.cs
+++ b/access-token-management/src/AccessTokenManagement/RefreshToken.cs
@@ -10,13 +10,21 @@ namespace Duende.AccessTokenManagement;
 [JsonConverter(typeof(StringValueJsonConverter<RefreshToken>))]
 public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
 {
-    public const int MaxLength = 4 * 1024;
+    private const int Kilobyte = 1024;
+
+    public const int MaxLength = 100 * Kilobyte;
     public override string ToString() => Value;
 
     private static readonly ValidationRule<string>[] Validators = [
-        // Officially, there's no max length refresh tokens, but 4k is a good limit
+        // Keep direct construction bounded. Runtime read boundaries apply the configurable limit.
         ValidationRules.MaxLength(MaxLength)
     ];
+
+    private static ValidationRule<string>[] BuildValidators(int maxLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxLength);
+        return [ValidationRules.MaxLength(maxLength)];
+    }
 
     /// <summary>
     /// You can't directly create this type.
@@ -40,10 +48,30 @@ public readonly record struct RefreshToken : IStronglyTypedValue<RefreshToken>
     public static bool TryParse(string value, [NotNullWhen(true)] out RefreshToken? parsed, out string[] errors) =>
         IStronglyTypedValue<RefreshToken>.TryBuildValidatedObject(value, Validators, out parsed, out errors);
 
+    /// <summary>
+    /// Parses a value to a <see cref="RefreshToken"/> using the supplied maximum length.
+    /// </summary>
+    public static bool TryParse(string value, int maxLength, [NotNullWhen(true)] out RefreshToken? parsed, out string[] errors) =>
+        IStronglyTypedValue<RefreshToken>.TryBuildValidatedObject(value, BuildValidators(maxLength), out parsed, out errors);
+
     static RefreshToken IStronglyTypedValue<RefreshToken>.Create(string result) => new(result);
 
     /// <summary>
     /// Parses a value to a <see cref="RefreshToken"/>. This will throw an exception if the string is not valid.
     /// </summary>
     public static RefreshToken Parse(string value) => StringParsers<RefreshToken>.Parse(value);
+
+    /// <summary>
+    /// Parses a value to a <see cref="RefreshToken"/> using the supplied maximum length.
+    /// </summary>
+    public static RefreshToken Parse(string value, int maxLength)
+    {
+        if (TryParse(value, maxLength, out var parsed, out var errors))
+        {
+            return parsed.Value;
+        }
+
+        throw new InvalidOperationException(
+            $"Received an invalid {nameof(RefreshToken)}. Errors: {string.Join("", errors.Select(x => $"{Environment.NewLine}\t - {x}"))}");
+    }
 }

--- a/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/ClientTokenManagementTests.cs
@@ -221,6 +221,30 @@ public class ClientTokenManagementTests
     }
 
     [Fact]
+    public async Task Access_token_from_token_response_should_use_configured_token_max_length()
+    {
+        _services.AddClientCredentialsTokenManagement(options => options.TokenMaxLength = 8)
+            .AddClient("test", client => Some.ClientCredentialsClient(client));
+
+        _mockHttp.Expect(The.TokenEndpoint.ToString())
+            .Respond(_ => Some.TokenHttpResponse(Some.Token() with
+            {
+                access_token = new string('a', 9)
+            }));
+
+        _services.AddHttpClient(ClientCredentialsTokenManagementDefaults.BackChannelHttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => _mockHttp);
+
+        var provider = _services.BuildServiceProvider();
+        var sut = provider.GetRequiredService<IClientCredentialsTokenManager>();
+
+        var action = async () => await sut.GetAccessTokenAsync(ClientCredentialsClientName.Parse("test"), ct: _ct);
+
+        (await Should.ThrowAsync<InvalidOperationException>(action))
+            .Message.ShouldContain("The string exceeds maximum length 8.");
+    }
+
+    [Fact]
     public async Task Request_parameters_should_take_precedence_over_configuration()
     {
         _services.AddClientCredentialsTokenManagement()

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi.verified.txt
@@ -3,11 +3,13 @@
     [System.Text.Json.Serialization.JsonConverter(typeof(Duende.AccessTokenManagement.Internal.StringValueJsonConverter<Duende.AccessTokenManagement.AccessToken>))]
     public readonly struct AccessToken : System.IEquatable<Duende.AccessTokenManagement.AccessToken>
     {
-        public const int MaxLength = 32768;
+        public const int MaxLength = 102400;
         public AccessToken() { }
         public override string ToString() { }
         public static Duende.AccessTokenManagement.AccessToken Parse(string value) { }
+        public static Duende.AccessTokenManagement.AccessToken Parse(string value, int maxLength) { }
         public static bool TryParse(string value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.AccessTokenManagement.AccessToken? parsed, out string[] errors) { }
+        public static bool TryParse(string value, int maxLength, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.AccessTokenManagement.AccessToken? parsed, out string[] errors) { }
         public static string op_Implicit(Duende.AccessTokenManagement.AccessToken value) { }
     }
     public sealed class AccessTokenRequestHandler : System.Net.Http.DelegatingHandler
@@ -102,6 +104,7 @@
         public System.TimeSpan DefaultCacheLifetime { get; set; }
         public System.TimeSpan? LocalCacheExpiration { get; set; }
         public string NonceStoreKeyPrefix { get; set; }
+        public int TokenMaxLength { get; set; }
         public bool UseCacheAutoTuning { get; set; }
     }
     [System.ComponentModel.TypeConverter(typeof(Duende.AccessTokenManagement.Internal.StringValueConverter<Duende.AccessTokenManagement.ClientId>))]
@@ -180,11 +183,13 @@
     [System.Text.Json.Serialization.JsonConverter(typeof(Duende.AccessTokenManagement.Internal.StringValueJsonConverter<Duende.AccessTokenManagement.RefreshToken>))]
     public readonly struct RefreshToken : System.IEquatable<Duende.AccessTokenManagement.RefreshToken>
     {
-        public const int MaxLength = 4096;
+        public const int MaxLength = 102400;
         public RefreshToken() { }
         public override string ToString() { }
         public static Duende.AccessTokenManagement.RefreshToken Parse(string value) { }
+        public static Duende.AccessTokenManagement.RefreshToken Parse(string value, int maxLength) { }
         public static bool TryParse(string value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.AccessTokenManagement.RefreshToken? parsed, out string[] errors) { }
+        public static bool TryParse(string value, int maxLength, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Duende.AccessTokenManagement.RefreshToken? parsed, out string[] errors) { }
         public static string op_Implicit(Duende.AccessTokenManagement.RefreshToken value) { }
     }
     [System.ComponentModel.TypeConverter(typeof(Duende.AccessTokenManagement.Internal.StringValueConverter<Duende.AccessTokenManagement.Resource>))]

--- a/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
+++ b/access-token-management/test/AccessTokenManagement.Tests/PublicApiVerificationTests.VerifyPublicApi_OpenIdConnect.verified.txt
@@ -118,6 +118,7 @@
         public Duende.AccessTokenManagement.Scope? ClientCredentialsScope { get; set; }
         public Duende.AccessTokenManagement.DPoP.DPoPProofKey? DPoPJsonWebKey { get; set; }
         public System.TimeSpan RefreshBeforeExpiration { get; set; }
+        public int TokenMaxLength { get; set; }
         public bool UseChallengeSchemeScopedTokens { get; set; }
     }
     public sealed class UserTokenRequestParameters : Duende.AccessTokenManagement.TokenRequestParameters, System.IEquatable<Duende.AccessTokenManagement.OpenIdConnect.UserTokenRequestParameters>

--- a/access-token-management/test/AccessTokenManagement.Tests/StoreTokensInAuthenticationPropertiesTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/StoreTokensInAuthenticationPropertiesTests.cs
@@ -38,6 +38,29 @@ public class StoreTokensInAuthenticationPropertiesTests
         CompareRefreshToken(result, userToken);
     }
 
+    [Fact]
+    public void Should_validate_access_token_length_using_options_when_retrieving_tokens()
+    {
+        var authenticationProperties = new AuthenticationProperties();
+        var sut = new StoreTokensInAuthenticationProperties(
+            new TestOptionsMonitor<UserTokenManagementOptions>(new UserTokenManagementOptions
+            {
+                TokenMaxLength = 8
+            }),
+            new TestOptionsMonitor<CookieAuthenticationOptions>(),
+            new TestSchemeProvider(),
+            new NullLogger<StoreTokensInAuthenticationProperties>()
+        );
+
+        authenticationProperties.Items[".Token.access_token"] = new string('a', 9);
+        authenticationProperties.Items[".Token.refresh_token"] = "refresh";
+        authenticationProperties.Items[".Token.client_id"] = "client";
+
+        var exception = Should.Throw<InvalidOperationException>(() => sut.GetUserToken(authenticationProperties));
+
+        exception.Message.ShouldContain("The string exceeds maximum length 8.");
+    }
+
     private static void CompareRefreshToken(TokenResult<TokenForParameters> result, UserToken userToken)
     {
         var userRefreshToken = result.Token!.RefreshToken.ShouldNotBeNull();

--- a/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementTests.cs
+++ b/access-token-management/test/AccessTokenManagement.Tests/UserTokenManagementTests.cs
@@ -231,6 +231,47 @@ public class UserTokenManagementTests(ITestOutputHelper output) : IntegrationTes
     }
 
     [Fact]
+    public async Task Refresh_token_response_should_use_configured_token_max_length()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        AppHost.IdentityServerHttpHandler = mockHttp;
+
+        var initialTokenResponse = new
+        {
+            id_token = IdentityServerHost.CreateIdToken("1", "web"),
+            access_token = "initial_access_token",
+            token_type = "tokentype",
+            expires_in = 10,
+            refresh_token = "initial_refresh_token",
+        };
+        mockHttp.When("/connect/token")
+            .WithFormData("grant_type", "authorization_code")
+            .Respond("application/json", JsonSerializer.Serialize(initialTokenResponse));
+
+        var refreshTokenResponse = new
+        {
+            access_token = new string('a', 9),
+            token_type = "tokentype1",
+            expires_in = 3600,
+            refresh_token = "refreshed_refresh_token",
+        };
+        mockHttp.When("/connect/token")
+            .WithFormData("grant_type", "refresh_token")
+            .WithFormData("refresh_token", "initial_refresh_token")
+            .Respond("application/json", JsonSerializer.Serialize(refreshTokenResponse));
+
+        AppHost.OnConfigureServices += services => services.Configure<UserTokenManagementOptions>(options => options.TokenMaxLength = 8);
+
+        await InitializeAsync();
+        await AppHost.LoginAsync("alice");
+
+        var action = async () => await AppHost.BrowserClient.GetAsync(AppHost.Url("/user_token"), _ct);
+
+        (await Should.ThrowAsync<InvalidOperationException>(action))
+            .Message.ShouldContain("The string exceeds maximum length 8.");
+    }
+
+    [Fact]
     public async Task Short_token_lifetime_should_trigger_refresh()
     {
         // This test makes an initial token request using code flow and then


### PR DESCRIPTION
This change makes token length validation configurable instead of relying on fixed limits baked into AccessToken and RefreshToken. This is needed because EntraID's refresh token length can be really long. 

The static hard caps on the token value objects were raised to 100 KB to avoid blocking customers with unusually large tokens, while a new TokenMaxLength setting (default: 32 KB) now controls the runtime validation ATM applies when tokens are first read from external sources. Validation remains in the OIDC authentication-properties rehydration path, which is still the first ATM-controlled read of initially issued user tokens.

### Changes
TokenMaxLength option added to both client-credentials and user-token management options
new Parse/TryParse overloads on AccessToken and RefreshToken for configurable max-length validation
validation placement: enforced at token read boundaries, but not re-applied during client-token cache deserialization

### Risk / impact
Default behavior remains effectively bounded at 32 KB unless consumers opt into a larger limit
Large tokens previously rejected by static type limits can now be accepted when configured
Cache rehydration now trusts tokens previously validated before storage, so correctness depends on validation happening at the initial read boundary